### PR TITLE
Remove virtualenv upperbound in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Install Ubuntu dependencies
         run: sudo apt-get install bzr
 
-      - run: pip install nox 'virtualenv<20' 'setuptools != 60.6.0'
+      - run: pip install nox virtualenv 'setuptools != 60.6.0'
 
       # Main check
       - name: Run integration tests


### PR DESCRIPTION
I'm starting to familiarize myself with pip's test suite, I notice it's dependency on virtualenv and how it is upper bounded in CI, meaning it's pulling virtualenv 16.7.12 which was released Jul 22, 2021.

I found some previous discusson on this, but I was unclear if it was actually resolved, it appeared to be discussing a lot about Python 2 support. I thought I'd make a PR and see if it just worked or if something needed fixing.