### PR TITLE
Remove legacy virtualenv<20 runtime support

### DIFF
--- a/news/drop-legacy-virtualenv-detection.removal.rst
+++ b/news/drop-legacy-virtualenv-detection.removal.rst
@@ -1,0 +1,1 @@
+Remove support for legacy ``virtualenv`` (older than version 20) environments.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -24,7 +24,7 @@ from pip._internal.exceptions import (
     InstallWheelBuildError,
     PipError,
 )
-from pip._internal.locations import get_platlib, get_purelib, get_scheme
+from pip._internal.locations import get_scheme
 from pip._internal.metadata import get_default_environment, get_environment
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.logging import VERBOSE, capture_logging
@@ -61,22 +61,8 @@ class _Prefix:
 
 
 def _get_system_sitepackages() -> set[str]:
-    """Get system site packages
-
-    Usually from site.getsitepackages,
-    but fallback on `get_purelib()/get_platlib()` if unavailable
-    (e.g. in a virtualenv created by virtualenv<20)
-
-    Returns normalized set of strings.
-    """
-    if hasattr(site, "getsitepackages"):
-        system_sites = site.getsitepackages()
-    else:
-        # virtualenv < 20 overwrites site.py without getsitepackages
-        # fallback on get_purelib/get_platlib.
-        # this is known to miss things, but shouldn't in the cases
-        # where getsitepackages() has been removed (inside a virtualenv)
-        system_sites = [get_purelib(), get_platlib()]
+    """Get system site packages, as a normalized set of strings."""
+    system_sites = site.getsitepackages()
     return {os.path.normcase(path) for path in system_sites}
 
 

--- a/src/pip/_internal/utils/virtualenv.py
+++ b/src/pip/_internal/utils/virtualenv.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import os
 import re
-import site
 import sys
 
 logger = logging.getLogger(__name__)
@@ -20,18 +19,9 @@ def _running_under_venv() -> bool:
     return sys.prefix != getattr(sys, "base_prefix", sys.prefix)
 
 
-def _running_under_legacy_virtualenv() -> bool:
-    """Checks if sys.real_prefix is set.
-
-    This handles virtual environments created with pypa's virtualenv.
-    """
-    # pypa/virtualenv case
-    return hasattr(sys, "real_prefix")
-
-
 def running_under_virtualenv() -> bool:
     """True if we're running inside a virtual environment, False otherwise."""
-    return _running_under_venv() or _running_under_legacy_virtualenv()
+    return _running_under_venv()
 
 
 def _get_pyvenv_cfg_lines() -> list[str] | None:
@@ -78,28 +68,9 @@ def _no_global_under_venv() -> bool:
     return False
 
 
-def _no_global_under_legacy_virtualenv() -> bool:
-    """Check if "no-global-site-packages.txt" exists beside site.py
-
-    This mirrors logic in pypa/virtualenv for determining whether system
-    site-packages are visible in the virtual environment.
-    """
-    site_mod_dir = os.path.dirname(os.path.abspath(site.__file__))
-    no_global_site_packages_file = os.path.join(
-        site_mod_dir,
-        "no-global-site-packages.txt",
-    )
-    return os.path.exists(no_global_site_packages_file)
-
-
 def virtualenv_no_global() -> bool:
     """Returns a boolean, whether running in venv with no system site-packages."""
-    # PEP 405 compliance needs to be checked first since virtualenv >=20 would
-    # return True for both checks, but is only able to use the PEP 405 config.
     if _running_under_venv():
         return _no_global_under_venv()
-
-    if _running_under_legacy_virtualenv():
-        return _no_global_under_legacy_virtualenv()
 
     return False

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -60,8 +60,6 @@ def _run_pip_without_virtualenv(
 
         # Simulate running outside a virtualenv.
         sys.base_prefix = sys.prefix
-        if hasattr(sys, "real_prefix"):
-            delattr(sys, "real_prefix")
 
         sys.argv = ["pip", {", ".join(repr(arg) for arg in args)}]
 

--- a/tests/unit/test_utils_virtualenv.py
+++ b/tests/unit/test_utils_virtualenv.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
-import site
 import sys
 from pathlib import Path
 
@@ -12,65 +10,24 @@ from pip._internal.utils import virtualenv
 
 
 @pytest.mark.parametrize(
-    "real_prefix, base_prefix, expected",
+    "base_prefix, expected",
     [
-        (None, None, False),  # Python 2 base interpreter
-        (None, sys.prefix, False),  # Python 3 base interpreter
-        (None, "not_sys_prefix", True),  # PEP405 venv
-        (sys.prefix, None, True),  # Unknown case
-        (sys.prefix, sys.prefix, True),  # Unknown case
-        (sys.prefix, "not_sys_prefix", True),  # Unknown case
-        ("not_sys_prefix", None, True),  # Python 2 virtualenv
-        ("not_sys_prefix", sys.prefix, True),  # Python 3 virtualenv
-        ("not_sys_prefix", "not_sys_prefix", True),  # Unknown case
+        (None, False),  # base_prefix missing, falls back to sys.prefix
+        (sys.prefix, False),  # base interpreter
+        ("not_sys_prefix", True),  # PEP 405 venv
     ],
 )
 def test_running_under_virtualenv(
     monkeypatch: pytest.MonkeyPatch,
-    real_prefix: str | None,
     base_prefix: str | None,
     expected: bool,
 ) -> None:
     # Use raising=False to prevent AttributeError on missing attribute
-    if real_prefix is None:
-        monkeypatch.delattr(sys, "real_prefix", raising=False)
-    else:
-        monkeypatch.setattr(sys, "real_prefix", real_prefix, raising=False)
     if base_prefix is None:
         monkeypatch.delattr(sys, "base_prefix", raising=False)
     else:
         monkeypatch.setattr(sys, "base_prefix", base_prefix, raising=False)
     assert virtualenv.running_under_virtualenv() == expected
-
-
-@pytest.mark.parametrize(
-    "under_virtualenv, no_global_file, expected",
-    [
-        (False, False, False),
-        (False, True, False),
-        (True, False, False),
-        (True, True, True),
-    ],
-)
-def test_virtualenv_no_global_with_regular_virtualenv(
-    monkeypatch: pytest.MonkeyPatch,
-    tmpdir: Path,
-    under_virtualenv: bool,
-    no_global_file: bool,
-    expected: bool,
-) -> None:
-    monkeypatch.setattr(virtualenv, "_running_under_venv", lambda: False)
-
-    monkeypatch.setattr(site, "__file__", os.fspath(tmpdir / "site.py"))
-    monkeypatch.setattr(
-        virtualenv,
-        "_running_under_legacy_virtualenv",
-        lambda: under_virtualenv,
-    )
-    if no_global_file:
-        (tmpdir / "no-global-site-packages.txt").touch()
-
-    assert virtualenv.virtualenv_no_global() == expected
 
 
 @pytest.mark.parametrize(
@@ -108,7 +65,6 @@ def test_virtualenv_no_global_with_pep_405_virtual_environment(
     expect_no_global: bool,
     expect_warning: bool,
 ) -> None:
-    monkeypatch.setattr(virtualenv, "_running_under_legacy_virtualenv", lambda: False)
     monkeypatch.setattr(virtualenv, "_get_pyvenv_cfg_lines", lambda: pyvenv_cfg_lines)
     monkeypatch.setattr(virtualenv, "_running_under_venv", lambda: under_venv)
 


### PR DESCRIPTION
`virtualenv` < 20 cannot create environments for the Python versions pip now supports (3.10+), so pip can never run under one. Remove the `sys.real_prefix` detection and `no-global-site-packages.txt` fallbacks from `pip._internal.utils.virtualenv` and `build_env`, along with the now-dead test scaffolding.
