### PR TITLE
Speed up Windows and zipapp CI by sharding the slow suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           --durations=15
 
   tests-windows:
-    name: tests / ${{ matrix.python }} / ${{ matrix.os }} / ${{ matrix.group.number }}
+    name: tests / ${{ matrix.python }} / ${{ matrix.os }} / ${{ matrix.group }}
     runs-on: ${{ matrix.os }}-latest
 
     needs: [determine-changes]
@@ -220,9 +220,9 @@ jobs:
           - "3.14"
           - "3.15"
           - "3.14t"
-        group:
-          - { number: 1, pytest-filter: "not test_install" }
-          - { number: 2, pytest-filter: "test_install" }
+        # Windows is slow, so shard unit + functional across runners, split by a
+        # stable hash of each test's node id (see --num-test-groups in conftest).
+        group: [1, 2]
 
     steps:
       # The D: drive is significantly faster than the system C: drive.
@@ -259,31 +259,35 @@ jobs:
       - run: python -m pip install .
       - run: python -m pip install nox
 
-      # Main check
-      - name: Run unit tests (group 1)
-        if: matrix.group.number == 1
+      # Main check. worksteal rebalances the long tail of slow install tests
+      # onto idle workers:
+      # https://pytest-xdist.readthedocs.io/en/stable/distribution.html
+      - name: Run tests (shard ${{ matrix.group }} of 2)
         run: >-
           python -m nox -s test-${{ matrix.python }} --
-          tests/unit
-          --verbose --numprocesses auto --showlocals
-
-      - name: Run integration tests (group ${{ matrix.group.number }})
-        run: >-
-          python -m nox -s test-${{ matrix.python }} --no-install --
-          tests/functional -k "${{ matrix.group.pytest-filter }}"
+          tests/unit tests/functional
+          --num-test-groups 2 --test-group ${{ matrix.group }}
           --verbose --numprocesses auto --showlocals --durations=15
+          --dist worksteal
 
   tests-zipapp:
-    name: tests / zipapp
-    # The macos-latest (M1) runners are the fastest available on GHA, even
-    # beating out the ubuntu-latest runners. The zipapp tests are slow by
-    # nature, and we don't care where they run, so we pick the fastest one.
-    runs-on: macos-latest
+    name: tests / zipapp / ${{ matrix.group }}
+    # Sharded, so we want spare capacity to start shards promptly over the
+    # fastest single runner. The suite is platform-agnostic and macos is
+    # capacity-limited.
+    runs-on: ubuntu-latest
 
     needs: [determine-changes]
     if: >-
       needs.determine-changes.outputs.tests == 'true' ||
       github.event_name != 'pull_request'
+
+    strategy:
+      fail-fast: true
+      matrix:
+        # A source-only zipapp recompiles every pip module per run (zipimport
+        # can't cache bytecode), so this suite is slow. Shard it across runners.
+        group: [1, 2]
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -293,20 +297,26 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install MacOS dependencies
-        run: brew install breezy subversion
+      - name: Install Ubuntu dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install brz subversion
 
       - run: python -m pip install .
       - run: python -m pip install nox
 
-      # Main check
-      - name: Run integration tests
+      # Main check. worksteal rebalances the long tail of slow tests onto idle
+      # workers:
+      # https://pytest-xdist.readthedocs.io/en/stable/distribution.html
+      - name: Run integration tests (shard ${{ matrix.group }} of 2)
         run: >-
           python -m nox -s test-3.10 --
           tests/functional
+          --num-test-groups 2 --test-group ${{ matrix.group }}
           --verbose --numprocesses auto --showlocals
           --durations=15
           --use-zipapp
+          --dist worksteal
 
   check:  # This job does nothing and is only used for the branch protection
     if: always()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import zlib
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
@@ -92,6 +93,20 @@ def pytest_addoption(parser: Parser) -> None:
         default=False,
         help="use a zipapp when running pip in tests",
     )
+    parser.addoption(
+        "--num-test-groups",
+        action="store",
+        type=int,
+        default=None,
+        help="split collected tests into this many groups, for parallel CI shards",
+    )
+    parser.addoption(
+        "--test-group",
+        action="store",
+        type=int,
+        default=None,
+        help="run only the given 1-based group (requires --num-test-groups)",
+    )
 
 
 def pytest_collection_modifyitems(config: Config, items: list[pytest.Function]) -> None:
@@ -140,6 +155,42 @@ def pytest_collection_modifyitems(config: Config, items: list[pytest.Function]) 
                 )
         else:
             raise RuntimeError(f"Unknown test type (filename = {module_path})")
+
+    _shard_collected_items(config, items)
+
+
+def _shard_collected_items(config: Config, items: list[pytest.Function]) -> None:
+    """Keep only the tests belonging to the configured CI shard.
+
+    Tests are assigned to a group by a stable hash of their node id, which keeps
+    the groups balanced by count and deterministic across xdist workers (so each
+    worker collects an identical subset). This lets CI run the suite across
+    several runners in parallel without overlapping work.
+    """
+    num_groups = config.getoption("--num-test-groups")
+    group = config.getoption("--test-group")
+    if num_groups is None and group is None:
+        return
+    if num_groups is None or group is None:
+        raise pytest.UsageError(
+            "--num-test-groups and --test-group must be supplied together"
+        )
+    if num_groups < 1 or not 1 <= group <= num_groups:
+        raise pytest.UsageError(
+            f"--test-group must be between 1 and --num-test-groups ({num_groups})"
+        )
+
+    selected: list[pytest.Function] = []
+    deselected: list[pytest.Function] = []
+    for item in items:
+        shard = zlib.crc32(item.nodeid.encode("utf-8")) % num_groups
+        if shard == group - 1:
+            selected.append(item)
+        else:
+            deselected.append(item)
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+    items[:] = selected
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
Shards pip's two slowest CI jobs, Windows and zipapp, across runners. A dependency-free sharder in `tests/conftest.py` (`--num-test-groups` / `--test-group`) splits tests by a stable `crc32` of their node id; each job runs 2 shards with `--dist worksteal`, and zipapp moves to Ubuntu.

Why:

- `worksteal` rebalances slow tests onto idle workers: https://pytest-xdist.readthedocs.io/en/stable/distribution.html
- `crc32`, not the `PYTHONHASHSEED`-salted `hash()`, keeps collection identical across xdist workers, which xdist requires or it aborts: https://github.com/pytest-dev/pytest-xdist/issues/432
- Same cross-runner split as pytest-split, hash-based to stay built-in: https://github.com/jerry-git/pytest-split
- macOS runners have far lower concurrency than Linux: https://docs.github.com/en/actions/reference/limits
