### PR TITLE
Fix Link.filename decoding URL path twice

### DIFF
--- a/news/14110.bugfix.rst
+++ b/news/14110.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``Link.filename`` decoding the URL path twice.

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -425,6 +425,7 @@ class Link:
 
     @property
     def filename(self) -> str:
+        # ``self.path`` is already unquoted in ``__init__``; don't unquote again.
         path = self.path.rstrip("/")
         name = posixpath.basename(path)
         if not name:
@@ -433,7 +434,6 @@ class Link:
             netloc, user_pass = split_auth_from_netloc(self.netloc)
             return netloc
 
-        name = urllib.parse.unquote(name)
         assert name, f"URL {self._url!r} produced no filename"
         return name
 

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -24,6 +24,7 @@ from pip._internal.network.cache import SafeFileCache, is_from_cache
 from pip._internal.network.session import CacheControlAdapter, PipSession
 from pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
 from pip._internal.utils.misc import format_size, redact_auth_from_url, splitext
+from pip._internal.utils.unpacking import join_within_directory
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +188,9 @@ class Downloader:
         resp = self._http_get(link)
         download_size = _get_http_response_size(resp)
 
-        filepath = os.path.join(location, _get_http_response_filename(resp, link))
+        filepath = join_within_directory(
+            location, _get_http_response_filename(resp, link)
+        )
         with open(filepath, "wb") as content_file:
             download = _FileDownload(link, content_file, download_size)
             self._process_response(download, resp)

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -53,7 +53,7 @@ from pip._internal.utils.misc import (
     redact_auth_from_requirement,
 )
 from pip._internal.utils.temp_dir import TempDirectory
-from pip._internal.utils.unpacking import unpack_file
+from pip._internal.utils.unpacking import join_within_directory, unpack_file
 from pip._internal.vcs import vcs
 
 if TYPE_CHECKING:
@@ -201,7 +201,7 @@ def _check_download_dir(
     """Check download_dir for previously downloaded file with correct hash
     If a correct file is found return its path else None
     """
-    download_path = os.path.join(download_dir, link.filename)
+    download_path = join_within_directory(download_dir, link.filename)
 
     if not os.path.exists(download_path):
         return None
@@ -687,7 +687,7 @@ class RequirementPreparer:
             # No distribution was downloaded for this requirement.
             return
 
-        download_location = os.path.join(self.download_dir, link.filename)
+        download_location = join_within_directory(self.download_dir, link.filename)
         if not os.path.exists(download_location):
             shutil.copy(req.local_file_path, download_location)
             download_path = display_path(download_location)

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -87,6 +87,19 @@ def is_within_directory(directory: str, target: str) -> bool:
     return abs_target == abs_directory or abs_target.startswith(abs_directory + os.sep)
 
 
+def join_within_directory(directory: str, name: str) -> str:
+    """Join ``name`` onto ``directory`` as a single path component.
+
+    ``name`` is reduced to its basename; ``ValueError`` is raised if that is
+    empty, ``.``, or ``..``.
+    """
+    name = os.path.basename(name)
+    target = os.path.join(directory, name)
+    if name in ("", os.curdir, os.pardir) or not is_within_directory(directory, target):
+        raise ValueError(f"Unexpected file name derived from URL: {name!r}")
+    return target
+
+
 def _get_default_mode_plus_executable() -> int:
     return 0o777 & ~current_umask() | 0o111
 

--- a/tests/unit/test_link.py
+++ b/tests/unit/test_link.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import posixpath
+
 import pytest
 
 from pip._internal.exceptions import InvalidEggFragment, PipError
@@ -29,6 +31,13 @@ class TestLink:
             ("https://example.com/path/page.html", "page.html"),
             # Test a quoted character.
             ("https://example.com/path/page%231.html", "page#1.html"),
+            # A doubly-encoded separator must stay encoded: the path is decoded
+            # exactly once, so the file name keeps its literal "%2F" instead of
+            # collapsing into a "/".
+            (
+                "https://example.com/a%252Fb.whl",
+                "a%2Fb.whl",
+            ),
             (
                 "http://yo/myproject-1.0%2Bfoobar.0-py2.py3-none-any.whl",
                 "myproject-1.0+foobar.0-py2.py3-none-any.whl",
@@ -48,6 +57,21 @@ class TestLink:
     def test_filename(self, url: str, expected: str) -> None:
         link = Link(url)
         assert link.filename == expected
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/a%252Fb.whl",
+            "https://example.com/%252e%252e%252fb.whl",
+        ],
+    )
+    def test_filename_decoded_once_stays_single_component(self, url: str) -> None:
+        # The path is decoded exactly once, so an encoded separator stays
+        # encoded and the file name remains a single path component rather
+        # than collapsing into a "/"-separated path.
+        filename = Link(url).filename
+        assert not posixpath.isabs(filename)
+        assert posixpath.basename(filename) == filename
 
     def test_splitext(self) -> None:
         assert ("wheel", ".whl") == Link("http://yo/wheel.whl").splitext()

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -19,6 +19,7 @@ from pip._internal.exceptions import InstallationError
 from pip._internal.utils.unpacking import (
     _get_default_mode_plus_executable,
     is_within_directory,
+    join_within_directory,
     unpack_file,
     untar_file,
     unzip_file,
@@ -471,6 +472,51 @@ def test_unpack_tar_unicode(tmpdir: Path) -> None:
 def test_is_within_directory(args: tuple[str, str], expected: bool) -> None:
     result = is_within_directory(*args)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "wheel.whl",
+        "myproject-1.0+foobar.0-py2.py3-none-any.whl",
+        # A literal "%2F" is a normal file name, not a separator.
+        "a%2Fb.whl",
+    ],
+)
+def test_join_within_directory_keeps_plain_name(name: str) -> None:
+    directory = os.path.join("base", "downloads")
+    assert join_within_directory(directory, name) == os.path.join(directory, name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        os.path.join(os.sep, "abs", "pkg.whl"),
+        os.path.join("..", "pkg.whl"),
+        os.path.join("nested", "pkg.whl"),
+    ],
+)
+def test_join_within_directory_collapses_path_to_basename(name: str) -> None:
+    # A name carrying directory components is reduced to its basename, so the
+    # result always lands directly inside the directory.
+    directory = os.path.join("base", "downloads")
+    expected = os.path.join(directory, os.path.basename(name))
+    assert join_within_directory(directory, name) == expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        ".",
+        "..",
+        "/",
+        os.path.join("sub", ".."),
+    ],
+)
+def test_join_within_directory_rejects_empty_or_dot_name(name: str) -> None:
+    with pytest.raises(ValueError):
+        join_within_directory("downloads", name)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`Link.__init__` already percent-decodes the URL path into `self._path`, but `Link.filename` decoded the basename again with `urllib.parse.unquote`. So a doubly-encoded separator was decoded twice: `%252F` became `%2F` in `__init__`, then `/` in `filename`, turning the single component `a%2Fb.whl` into `a/b.whl`.

Remove the second decode. Add `join_within_directory`, which reduces a name to its basename and raises `ValueError` if that is empty, `.`, or `..`, and route the three download-path joins through it: `_check_download_dir`, the copy into the `--download` directory, and the streaming download write.

Add unit tests for the decode-once behavior and the helper.
