### PR TITLE
Fix extra != marker evaluation

### DIFF
--- a/news/14139.bugfix.rst
+++ b/news/14139.bugfix.rst
@@ -1,0 +1,5 @@
+Evaluate ``extra`` environment markers on a dependency against the full set of
+extras requested for the package, so ``extra != "name"`` behaves as ``"name"
+not in extras``. Previously such a marker was always treated as active, so a
+dependency guarded by (for example) ``extra != "gpu"`` was installed even when
+the ``gpu`` extra was requested.

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -30,6 +30,7 @@ from pip._internal.models.direct_url import (
 )
 from pip._internal.utils.egg_link import egg_link_path_from_sys_path
 from pip._internal.utils.misc import is_local, normalize_path
+from pip._internal.utils.packaging import evaluate_marker_with_extras, get_requirement
 from pip._internal.utils.urls import url_to_path
 
 from ._json import msg_to_json
@@ -441,12 +442,20 @@ class BaseDistribution(Protocol):
         return spec
 
     def iter_dependencies(self, extras: Collection[str] = ()) -> Iterable[Requirement]:
-        """Dependencies of this distribution.
+        """Dependencies of this distribution active for the given extras.
 
         For modern .dist-info distributions, this is the collection of
-        "Requires-Dist:" entries in distribution metadata.
+        "Requires-Dist:" entries in distribution metadata. Each entry's marker
+        is evaluated against ``extras`` as a whole set, so ``extra != "x"`` (and
+        other non-equality operators) behave as set membership rather than being
+        unioned over one extra at a time.
         """
-        raise NotImplementedError()
+        for req_string in self.iter_raw_dependencies():
+            # strip() because email.message.Message.get_all() may return a leading \n
+            # in case a long header was wrapped.
+            req = get_requirement(req_string.strip())
+            if req.marker is None or evaluate_marker_with_extras(req.marker, extras):
+                yield req
 
     def iter_raw_dependencies(self) -> Iterable[str]:
         """Raw Requires-Dist metadata."""

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -4,13 +4,12 @@ import email.message
 import importlib.metadata
 import pathlib
 import zipfile
-from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping
 from os import PathLike
 from typing import (
     cast,
 )
 
-from pip._vendor.packaging.requirements import Requirement
 from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 from pip._vendor.packaging.version import Version
 from pip._vendor.packaging.version import parse as parse_version
@@ -23,7 +22,6 @@ from pip._internal.metadata.base import (
     Wheel,
 )
 from pip._internal.utils.misc import normalize_path
-from pip._internal.utils.packaging import get_requirement
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.wheel import parse_wheel, read_wheel_metadata_file
 
@@ -220,16 +218,3 @@ class Distribution(BaseDistribution):
             canonicalize_name(extra)
             for extra in self.metadata.get_all("Provides-Extra", [])
         ]
-
-    def iter_dependencies(self, extras: Collection[str] = ()) -> Iterable[Requirement]:
-        contexts: Sequence[dict[str, str]] = [{"extra": e} for e in extras]
-        for req_string in self.metadata.get_all("Requires-Dist", []):
-            # strip() because email.message.Message.get_all() may return a leading \n
-            # in case a long header was wrapped.
-            req = get_requirement(req_string.strip())
-            if not req.marker:
-                yield req
-            elif not extras and req.marker.evaluate({"extra": ""}):
-                yield req
-            elif any(req.marker.evaluate(context) for context in contexts):
-                yield req

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -236,6 +236,10 @@ class Distribution(BaseDistribution):
         return feed_parser.close()
 
     def iter_dependencies(self, extras: Collection[str] = ()) -> Iterable[Requirement]:
+        # This backend reads dependencies via pkg_resources (which covers legacy
+        # egg-info distributions whose deps live in requires.txt, not
+        # Requires-Dist), so it keeps its own implementation rather than the
+        # shared, Requires-Dist-based one in BaseDistribution.
         if extras:
             relevant_extras = set(self._extra_mapping) & set(
                 map(canonicalize_name, extras)

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -20,6 +20,10 @@ from pip._internal.distributions import make_distribution_for_install_requiremen
 from pip._internal.metadata import get_default_environment
 from pip._internal.metadata.base import BaseDistribution
 from pip._internal.req.req_install import InstallRequirement
+from pip._internal.utils.packaging import (
+    evaluate_marker_with_extras,
+    marker_references_extra,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +31,10 @@ logger = logging.getLogger(__name__)
 class PackageDetails(NamedTuple):
     version: Version
     dependencies: list[Requirement]
+    # The extras the package was installed with, when known. ``None`` means the
+    # package was already installed and pip does not record its requested
+    # extras, so extra-conditional dependencies cannot be verified.
+    requested_extras: frozenset[NormalizedName] | None = None
 
 
 # Shorthands
@@ -84,7 +92,18 @@ def check_package_set(
             if name not in package_set:
                 missed = True
                 if req.marker is not None:
-                    missed = req.marker.evaluate({"extra": ""})
+                    extras = package_detail.requested_extras
+                    if extras is None and marker_references_extra(req.marker):
+                        # Already-installed package: whether this dependency
+                        # applies depends on which extras it was installed with,
+                        # which pip does not record. Skip it to avoid false "not
+                        # installed" reports for deps gated on (e.g.)
+                        # ``extra != "x"``.
+                        missed = False
+                    else:
+                        missed = evaluate_marker_with_extras(
+                            req.marker, extras or frozenset()
+                        )
                 if missed:
                     missing_deps.add((name, req))
                 continue
@@ -150,7 +169,15 @@ def _simulate_installation_of(
         abstract_dist = make_distribution_for_install_requirement(inst_req)
         dist = abstract_dist.get_metadata_distribution()
         name = dist.canonical_name
-        package_set[name] = PackageDetails(dist.version, list(dist.iter_dependencies()))
+        # We know exactly which extras this package is being installed with, so
+        # evaluate its dependencies against them (this makes extra-conditional
+        # deps, e.g. ``extra != "x"``, resolve correctly for the new install).
+        requested_extras = frozenset(canonicalize_name(e) for e in inst_req.extras)
+        package_set[name] = PackageDetails(
+            dist.version,
+            list(dist.iter_dependencies(requested_extras)),
+            requested_extras,
+        )
 
         installed.add(name)
 

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -48,7 +48,10 @@ from pip._internal.utils.misc import (
     redact_auth_from_requirement,
     redact_auth_from_url,
 )
-from pip._internal.utils.packaging import get_requirement
+from pip._internal.utils.packaging import (
+    evaluate_marker_with_extras,
+    get_requirement,
+)
 from pip._internal.utils.subprocess import runner_with_spinner_message
 from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 from pip._internal.utils.unpacking import unpack_file
@@ -266,16 +269,13 @@ class InstallRequirement:
         return len(specifiers) == 1 and next(iter(specifiers)).operator in {"==", "==="}
 
     def match_markers(self, extras_requested: Iterable[str] | None = None) -> bool:
-        if not extras_requested:
-            # Provide an extra to safely evaluate the markers
-            # without matching any extra
-            extras_requested = ("",)
-        if self.markers is not None:
-            return any(
-                self.markers.evaluate({"extra": extra}) for extra in extras_requested
-            )
-        else:
+        if self.markers is None:
             return True
+        # Evaluate the markers against the *whole* set of requested extras, so
+        # that ``extra != "x"`` (and other non-equality operators) behave as
+        # set membership rather than being unioned over one extra at a time.
+        extras = set(extras_requested) if extras_requested else set()
+        return evaluate_marker_with_extras(self.markers, extras)
 
     @property
     def has_hash_options(self) -> bool:

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -139,6 +139,16 @@ class Candidate:
         raise NotImplementedError("Override in subclass")
 
     @property
+    def base_candidate(self) -> Candidate:
+        """The underlying installation candidate.
+
+        For a plain candidate this is itself; an ``ExtrasCandidate`` overrides
+        this to return the candidate it wraps. Two candidates that share a base
+        install the same thing and differ only in requested extras.
+        """
+        return self
+
+    @property
     def version(self) -> Version:
         raise NotImplementedError("Override in subclass")
 

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -21,6 +21,7 @@ from pip._internal.metadata import BaseDistribution
 from pip._internal.models.link import Link, links_equivalent
 from pip._internal.models.wheel import Wheel
 from pip._internal.req.constructors import (
+    install_req_extend_extras,
     install_req_from_editable,
     install_req_from_line,
 )
@@ -200,6 +201,13 @@ class _InstallRequirementBackedCandidate(Candidate):
     @property
     def name(self) -> str:
         return self.project_name
+
+    @property
+    def extras(self) -> frozenset[NormalizedName]:
+        # A base candidate carries no extras; extras are modelled by
+        # ExtrasCandidate. Kept so requirements can uniformly check whether a
+        # candidate provides the extras they request.
+        return frozenset()
 
     @property
     def version(self) -> Version:
@@ -406,6 +414,11 @@ class AlreadyInstalledCandidate(Candidate):
         return self.project_name
 
     @property
+    def extras(self) -> frozenset[NormalizedName]:
+        # See _InstallRequirementBackedCandidate.extras.
+        return frozenset()
+
+    @property
     def version(self) -> Version:
         if self._version is None:
             self._version = self.dist.version
@@ -433,28 +446,25 @@ class AlreadyInstalledCandidate(Candidate):
 
 
 class ExtrasCandidate(Candidate):
-    """A candidate that has 'extras', indicating additional dependencies.
+    """A base candidate wrapped with a set of requested extras.
 
-    Requirements can be for a project with dependencies, something like
-    foo[extra].  The extras don't affect the project/version being installed
-    directly, but indicate that we need additional dependencies. We model that
-    by having an artificial ExtrasCandidate that wraps the "base" candidate.
+    Requirements can ask for a project together with extras, like foo[extra].
+    Extras don't change the project/version being installed, only which
+    dependencies are pulled in. They are modelled as an attribute of a single
+    candidate rather than as a separate resolver node: identify() returns the
+    bare project name, so foo and foo[extra] share one identity and the project
+    is resolved once against the merged set of requested extras. This is what
+    makes ``extra != "x"`` markers behave correctly: a dependency an extra
+    removes cannot be expressed if foo and foo[extra] are independent nodes.
 
-    The ExtrasCandidate differs from the base in the following ways:
+    So this candidate:
 
-    1. It has a unique name, of the form foo[extra]. This causes the resolver
-       to treat it as a separate node in the dependency graph.
-    2. When we're getting the candidate's dependencies,
-       a) We specify that we want the extra dependencies as well.
-       b) We add a dependency on the base candidate.
-          See below for why this is needed.
-    3. We return None for the underlying InstallRequirement, as the base
-       candidate will provide it, and we don't want to end up with duplicates.
-
-    The dependency on the base candidate is needed so that the resolver can't
-    decide that it should recommend foo[extra1] version 1.0 and foo[extra2]
-    version 2.0. Having those candidates depend on foo=1.0 and foo=2.0
-    respectively forces the resolver to recognise that this is a conflict.
+    1. Reports project_name (and identify()) as the base, sharing the base's
+       identity; only its display name and __str__ carry the [extras] suffix.
+    2. Yields the base's Requires-Python and the dependencies evaluated against
+       the requested extras. It does not depend on a separate base node.
+    3. Provides the base's InstallRequirement with the extras attached, so the
+       installation and its reported extras come from a single candidate.
     """
 
     def __init__(
@@ -474,7 +484,12 @@ class ExtrasCandidate(Candidate):
         """
         self.base = base
         self.extras = frozenset(canonicalize_name(e) for e in extras)
-        self._comes_from = comes_from if comes_from is not None else self.base._ireq
+        base_comes_from = comes_from if comes_from is not None else self.base._ireq
+        # Name the requested extras in the provenance chain (e.g. "(from
+        # pkg[extra])") so a dependency an extra pulled in reports that extra,
+        # even when this candidate was created from a plain requirement for the
+        # same project (e.g. installing pkg and pkg[extra] together).
+        self._comes_from = install_req_extend_extras(base_comes_from, self.extras)
 
     def __str__(self) -> str:
         name, rest = str(self.base).split(" ", 1)
@@ -490,6 +505,10 @@ class ExtrasCandidate(Candidate):
         if isinstance(other, self.__class__):
             return self.base == other.base and self.extras == other.extras
         return False
+
+    @property
+    def base_candidate(self) -> Candidate:
+        return self.base
 
     @property
     def project_name(self) -> NormalizedName:
@@ -524,9 +543,11 @@ class ExtrasCandidate(Candidate):
     def iter_dependencies(self, with_requires: bool) -> Iterable[Requirement | None]:
         factory = self.base._factory
 
-        # Add a dependency on the exact base
-        # (See note 2b in the class docstring)
-        yield factory.make_requirement_from_candidate(self.base)
+        # Extras are an attribute of this single candidate rather than a
+        # separate resolver node, so emit the base's Requires-Python and the
+        # dependencies evaluated against the requested extras directly. There is
+        # no dependency on a separate base candidate to add.
+        yield factory.make_requires_python_requirement(self.base.dist.requires_python)
         if not with_requires:
             return
 
@@ -550,10 +571,15 @@ class ExtrasCandidate(Candidate):
             )
 
     def get_install_requirement(self) -> InstallRequirement | None:
-        # We don't return anything here, because we always
-        # depend on the base candidate, and we'll get the
-        # install requirement from that.
-        return None
+        # Extras don't change what gets installed, only which dependencies are
+        # pulled in, so the installation comes from the base candidate. The
+        # requested extras are recorded on the returned requirement so later
+        # stages (e.g. the post-install consistency check) know which extras
+        # this package was installed with.
+        base_ireq = self.base.get_install_requirement()
+        if base_ireq is None:
+            return None
+        return install_req_extend_extras(base_ireq, self.extras)
 
 
 class RequiresPythonCandidate(Candidate):
@@ -584,6 +610,11 @@ class RequiresPythonCandidate(Candidate):
     @property
     def name(self) -> str:
         return REQUIRES_PYTHON_IDENTIFIER
+
+    @property
+    def extras(self) -> frozenset[NormalizedName]:
+        # See _InstallRequirementBackedCandidate.extras.
+        return frozenset()
 
     @property
     def version(self) -> Version:

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import copy
 import functools
 import logging
@@ -13,7 +12,6 @@ from typing import (
     cast,
 )
 
-from pip._vendor.packaging.requirements import InvalidRequirement
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 from pip._vendor.packaging.version import InvalidVersion, Version
@@ -47,7 +45,11 @@ from pip._internal.req.req_install import (
 from pip._internal.resolution.base import InstallRequirementProvider
 from pip._internal.utils.compatibility_tags import get_supported
 from pip._internal.utils.hashes import Hashes
-from pip._internal.utils.packaging import get_requirement
+from pip._internal.utils.packaging import (
+    evaluate_marker_with_extras,
+    get_requirement,
+    marker_references_extra,
+)
 from pip._internal.utils.virtualenv import running_under_virtualenv
 
 from .base import Candidate, Constraint, Requirement
@@ -80,6 +82,26 @@ logger = logging.getLogger(__name__)
 
 C = TypeVar("C")
 Cache = dict[Link, C]
+
+
+def _has_extra_removable_dependencies(dist: BaseDistribution) -> bool:
+    """Whether ``dist`` has a dependency that requesting an extra can remove.
+
+    These are dependencies whose marker references ``extra`` yet is active with
+    no extras requested, e.g. ``foo; extra != "gpu"``: present by default, but
+    dropped once ``gpu`` is requested.
+    """
+    for req_string in dist.iter_raw_dependencies():
+        if "extra" not in req_string:
+            continue
+        req = get_requirement(req_string.strip())
+        if (
+            req.marker is not None
+            and marker_references_extra(req.marker)
+            and evaluate_marker_with_extras(req.marker, frozenset())
+        ):
+            return True
+    return False
 
 
 class CollectedRootRequirements(NamedTuple):
@@ -117,6 +139,10 @@ class Factory:
         self._extras_candidate_cache: dict[
             tuple[int, frozenset[NormalizedName]], ExtrasCandidate
         ] = {}
+        # Per-project-name: does the project have a dependency an extra can
+        # remove (e.g. ``foo; extra != "x"``)? Recorded as base candidates are
+        # built and read by the resolver's preference nudge.
+        self._extra_removable_packages: dict[str, bool] = {}
         self._supported_tags_cache = get_supported()
 
         if not ignore_installed:
@@ -161,15 +187,19 @@ class Factory:
         dist: BaseDistribution,
         extras: frozenset[str],
         template: InstallRequirement,
+        comes_from: InstallRequirement | None = None,
     ) -> Candidate:
         try:
             base = self._installed_candidate_cache[dist.canonical_name]
         except KeyError:
             base = AlreadyInstalledCandidate(dist, template, factory=self)
             self._installed_candidate_cache[dist.canonical_name] = base
+        self._note_base_candidate(base)
         if not extras:
             return base
-        return self._make_extras_candidate(base, extras, comes_from=template)
+        return self._make_extras_candidate(
+            base, extras, comes_from=comes_from if comes_from is not None else template
+        )
 
     def _make_candidate_from_link(
         self,
@@ -178,13 +208,19 @@ class Factory:
         template: InstallRequirement,
         name: NormalizedName | None,
         version: Version | None,
+        comes_from: InstallRequirement | None = None,
     ) -> Candidate | None:
         base: BaseCandidate | None = self._make_base_candidate_from_link(
             link, template, name, version
         )
-        if not extras or base is None:
+        if base is None:
+            return None
+        self._note_base_candidate(base)
+        if not extras:
             return base
-        return self._make_extras_candidate(base, extras, comes_from=template)
+        return self._make_extras_candidate(
+            base, extras, comes_from=comes_from if comes_from is not None else template
+        )
 
     def _make_base_candidate_from_link(
         self,
@@ -242,6 +278,23 @@ class Factory:
                     self._build_failures[link] = e
                     return None
             return self._link_candidate_cache[link]
+
+    def _note_base_candidate(self, candidate: BaseCandidate) -> None:
+        """Record whether ``candidate``'s project has an extra-removable
+        dependency, for the resolver's preference nudge (see PipProvider)."""
+        name = candidate.project_name
+        if name not in self._extra_removable_packages:
+            self._extra_removable_packages[name] = _has_extra_removable_dependencies(
+                candidate.dist
+            )
+
+    def has_removable_extra_dependency(self, name: str) -> bool:
+        """Whether the named project has a dependency an extra can remove.
+
+        Reflects only the base candidates built so far, so this is a best-effort
+        signal for get_preference, not an authoritative answer.
+        """
+        return self._extra_removable_packages.get(name, False)
 
     def _get_locked_installation_candidate(
         self, ireqs: Sequence[InstallRequirement], name: str, specifier: SpecifierSet
@@ -305,6 +358,12 @@ class Factory:
             hashes &= ireq.hashes(trust_internet=False)
             extras |= frozenset(ireq.extras)
 
+        # For the "(from pkg[extra])" provenance chain, prefer a requirement that
+        # carries extras: its parent is the real requester, so naming the extras
+        # on it adds no hop. Falling back to an extras-dropped template would
+        # double the chain, since that template's own parent already names them.
+        comes_from = next((ireq for ireq in ireqs if ireq.extras), template)
+
         def _get_installed_candidate() -> Candidate | None:
             """Get the candidate for the currently-installed version."""
             # If --force-reinstall is set, we want the version from the index
@@ -328,6 +387,7 @@ class Factory:
                 dist=installed_dist,
                 extras=extras,
                 template=template,
+                comes_from=comes_from,
             )
             # The candidate is a known incompatibility. Don't use it.
             if id(candidate) in incompatible_ids:
@@ -379,6 +439,7 @@ class Factory:
                     template=template,
                     name=name,
                     version=ican.version,
+                    comes_from=comes_from,
                 )
                 yield ican.version, func
 
@@ -389,60 +450,27 @@ class Factory:
             incompatible_ids,
         )
 
-    def _iter_explicit_candidates_from_base(
-        self,
-        base_requirements: Iterable[Requirement],
-        extras: frozenset[str],
-    ) -> Iterator[Candidate]:
-        """Produce explicit candidates from the base given an extra-ed package.
-
-        :param base_requirements: Requirements known to the resolver. The
-            requirements are guaranteed to not have extras.
-        :param extras: The extras to inject into the explicit requirements'
-            candidates.
-        """
-        for req in base_requirements:
-            lookup_cand, _ = req.get_candidate_lookup()
-            if lookup_cand is None:  # Not explicit.
-                continue
-            # We've stripped extras from the identifier, and should always
-            # get a BaseCandidate here, unless there's a bug elsewhere.
-            base_cand = as_base_candidate(lookup_cand)
-            assert base_cand is not None, "no extras here"
-            yield self._make_extras_candidate(base_cand, extras)
-
     def _iter_candidates_from_constraints(
         self,
         identifier: str,
         constraint: Constraint,
         template: InstallRequirement,
     ) -> Iterator[Candidate]:
-        """Produce explicit candidates from constraints.
+        """Produce base candidates from a constraint's links.
 
         This creates "fake" InstallRequirement objects that are basically clones
-        of what "should" be the template, but with original_link set to link.
+        of what "should" be the template, but with original_link set to link. Any
+        requested extras are applied by find_candidates, not here.
         """
-        extras: frozenset[str] = frozenset()
-        base_identifier = identifier
-        with contextlib.suppress(InvalidRequirement):
-            parsed_requirement = get_requirement(identifier)
-            if parsed_requirement.name != identifier:
-                base_identifier = canonicalize_name(parsed_requirement.name)
-                extras = frozenset(parsed_requirement.extras)
-
         for link in constraint.links:
             self._fail_if_link_is_unsupported_wheel(link)
             base_candidate = self._make_base_candidate_from_link(
                 link,
                 template=install_req_from_link_and_ireq(link, template),
-                name=canonicalize_name(base_identifier),
+                name=canonicalize_name(identifier),
                 version=None,
             )
-            if base_candidate is None:
-                continue
-            if extras:
-                yield self._make_extras_candidate(base_candidate, extras)
-            else:
+            if base_candidate is not None:
                 yield base_candidate
 
     def find_candidates(
@@ -464,22 +492,6 @@ class Factory:
             if ireq is not None:
                 ireqs.append(ireq)
 
-        # If the current identifier contains extras, add requires and explicit
-        # candidates from entries from extra-less identifier.
-        with contextlib.suppress(InvalidRequirement):
-            parsed_requirement = get_requirement(identifier)
-            if parsed_requirement.name != identifier:
-                explicit_candidates.update(
-                    self._iter_explicit_candidates_from_base(
-                        requirements.get(parsed_requirement.name, ()),
-                        frozenset(parsed_requirement.extras),
-                    ),
-                )
-                for req in requirements.get(parsed_requirement.name, []):
-                    _, ireq = req.get_candidate_lookup()
-                    if ireq is not None:
-                        ireqs.append(ireq)
-
         # Add explicit candidates from constraints. We only do this if there are
         # known ireqs, which represent requirements not already explicit. If
         # there are no ireqs, we're constraining already-explicit requirements,
@@ -497,6 +509,26 @@ class Factory:
                 # If we're constrained to install a wheel incompatible with the
                 # target architecture, no candidates will ever be valid.
                 return ()
+
+        # Extras are modelled as an attribute of the candidate, so every explicit
+        # base candidate (from a link/URL or a constraint) must also be offered
+        # carrying the full set of extras requested for this identifier. That way
+        # one candidate can satisfy both a plain requirement on the base and a
+        # requirement that asks for its extras (e.g. `pip install ./pkg.whl other`
+        # where `other` depends on `pkg[extra]`). This runs after constraints so
+        # constraint-provided candidates are wrapped too.
+        requested_extras: frozenset[NormalizedName] = frozenset()
+        for ireq in ireqs:
+            requested_extras |= frozenset(canonicalize_name(e) for e in ireq.extras)
+        for cand in list(explicit_candidates):
+            requested_extras |= cand.extras
+        if requested_extras:
+            for cand in list(explicit_candidates):
+                base_cand = as_base_candidate(cand)
+                if base_cand is not None:
+                    explicit_candidates.add(
+                        self._make_extras_candidate(base_cand, requested_extras)
+                    )
 
         # Since we cache all the candidates, incompatibility identification
         # can be made quicker by comparing only the id() values.
@@ -567,10 +599,15 @@ class Factory:
                     raise self._build_failures[ireq.link]
                 yield UnsatisfiableRequirement(canonicalize_name(ireq.name))
             else:
-                # require the base from the link
+                # Require the base from the link. This registers the explicit
+                # candidate for the (extras-less) identifier so other
+                # requirements on the same project can resolve to it.
                 yield self.make_requirement_from_candidate(cand)
                 if ireq.extras:
-                    # require the extras on top of the base candidate
+                    # The extras candidate wraps the same base and carries the
+                    # requested extras; find_candidates offers it for the shared
+                    # identifier, and it satisfies both this and the base
+                    # requirement (extras only add dependencies).
                     yield self.make_requirement_from_candidate(
                         self._make_extras_candidate(cand, frozenset(ireq.extras))
                     )
@@ -603,8 +640,13 @@ class Factory:
                 if not reqs:
                     continue
                 template = reqs[0]
-                if ireq.user_supplied and template.name not in collected.user_requested:
-                    collected.user_requested[template.name] = i
+                # Key on project_name, matching identify(): the resolver looks up
+                # user_requested by the bare (extras-less) identifier, so a
+                # user-supplied foo[extra] must register under foo (otherwise its
+                # upgrade eligibility and requested ordering are lost).
+                name = template.project_name
+                if ireq.user_supplied and name not in collected.user_requested:
+                    collected.user_requested[name] = i
                 collected.requirements.extend(reqs)
         # Put requirements with extras at the end of the root requires. This does not
         # affect resolvelib's picking preference but it does affect its initial criteria

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable, Iterator, Mapping, Sequence
 from functools import cache
 from typing import (
     TYPE_CHECKING,
-    TypeVar,
 )
 
 from pip._vendor.resolvelib.providers import AbstractProvider
@@ -49,35 +48,6 @@ _CONFLICT_PRIORITY_THRESHOLD = 5
 # services to those objects (access to pip's finder and preparer).
 
 
-D = TypeVar("D")
-V = TypeVar("V")
-
-
-def _get_with_identifier(
-    mapping: Mapping[str, V],
-    identifier: str,
-    default: D,
-) -> D | V:
-    """Get item from a package name lookup mapping with a resolver identifier.
-
-    This extra logic is needed when the target mapping is keyed by package
-    name, which cannot be directly looked up with an identifier (which may
-    contain requested extras). Additional logic is added to also look up a value
-    by "cleaning up" the extras from the identifier.
-    """
-    if identifier in mapping:
-        return mapping[identifier]
-    # HACK: Theoretically we should check whether this identifier is a valid
-    # "NAME[EXTRAS]" format, and parse out the name part with packaging or
-    # some regular expression. But since pip's resolver only spits out three
-    # kinds of identifiers: normalized PEP 503 names, normalized names plus
-    # extras, and Requires-Python, we can cheat a bit here.
-    name, open_bracket, _ = identifier.partition("[")
-    if open_bracket and name in mapping:
-        return mapping[name]
-    return default
-
-
 class PipProvider(_ProviderBase):
     """Pip's provider implementation for resolvelib.
 
@@ -115,7 +85,12 @@ class PipProvider(_ProviderBase):
         return self._constraints
 
     def identify(self, requirement_or_candidate: Requirement | Candidate) -> str:
-        return requirement_or_candidate.name
+        # Extras are modelled as an attribute of the candidate rather than as a
+        # separate resolver node, so ``foo`` and ``foo[extra]`` share a single
+        # identity. This lets a package be resolved once against the merged set
+        # of requested extras, which is required for ``extra != "x"`` markers to
+        # behave correctly (see the ExtrasCandidate docstring).
+        return requirement_or_candidate.project_name
 
     def narrow_requirement_selection(
         self,
@@ -139,11 +114,13 @@ class PipProvider(_ProviderBase):
               get promoted so they are resolved earlier. This lets their
               constraints take effect before other packages pick a version.
         """
+        # Key on project_name, matching identify(): extras are folded into the
+        # base node, so a foo[extra] requirement/parent must count against foo.
         backtrack_identifiers = set()
         for info in backtrack_causes:
-            names = [info.requirement.name]
+            names = [info.requirement.project_name]
             if info.parent is not None:
-                names.append(info.parent.name)
+                names.append(info.parent.project_name)
             for name in names:
                 backtrack_identifiers.add(name)
                 if name not in resolutions:
@@ -243,11 +220,19 @@ class PipProvider(_ProviderBase):
 
         conflict_promoted = identifier in self._conflict_promoted
 
+        # Best-effort: resolve a package whose dependencies an extra can remove
+        # after other packages, so a later, transitively-requested extra (which
+        # would drop such a dependency) is discovered before this package is
+        # decided. This is only a nudge; it cannot always avoid deciding the
+        # package before such an extra becomes known.
+        defer_for_extras = self._factory.has_removable_extra_dependency(identifier)
+
         return (
             not conflict_promoted,
             not direct,
             not pinned,
             not upper_bounded,
+            defer_for_extras,
             requested_order,
             not unfree,
             identifier,
@@ -273,18 +258,12 @@ class PipProvider(_ProviderBase):
             if self._upgrade_strategy == "eager":
                 return True
             elif self._upgrade_strategy == "only-if-needed":
-                user_order = _get_with_identifier(
-                    self._user_requested,
-                    identifier,
-                    default=None,
-                )
-                return user_order is not None
+                return identifier in self._user_requested
             return False
 
-        constraint = _get_with_identifier(
-            self._constraints,
+        constraint = self._constraints.get(
             identifier,
-            default=Constraint.empty(),
+            Constraint.empty(),
         )
         return self._factory.find_candidates(
             identifier=identifier,

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -46,7 +46,15 @@ class ExplicitRequirement(Requirement):
         return self.candidate, None
 
     def is_satisfied_by(self, candidate: Candidate) -> bool:
-        return candidate == self.candidate
+        if candidate == self.candidate:
+            return True
+        # Extras are modelled as an attribute of the candidate, so a candidate
+        # that wraps the required one with additional extras also satisfies this
+        # requirement (extras only add dependencies). Compare the underlying base
+        # candidate and require the extras to cover what was originally asked.
+        if candidate.base_candidate != self.candidate.base_candidate:
+            return False
+        return self.candidate.extras <= candidate.extras
 
 
 class SpecifierRequirement(Requirement):
@@ -109,10 +117,15 @@ class SpecifierRequirement(Requirement):
         return None, self._ireq
 
     def is_satisfied_by(self, candidate: Candidate) -> bool:
-        assert candidate.name == self.name, (
+        assert candidate.project_name == self.project_name, (
             f"Internal issue: Candidate is not for this requirement "
-            f"{candidate.name} vs {self.name}"
+            f"{candidate.project_name} vs {self.project_name}"
         )
+        # Extras are modelled as an attribute of the candidate, so the candidate
+        # must provide every extra this requirement asks for. Extras are
+        # additive, so a candidate carrying more extras still satisfies.
+        if not self._extras <= candidate.extras:
+            return False
         # We can safely always allow prereleases here since PackageFinder
         # already implements the prerelease logic, and would have filtered out
         # prerelease candidates if the user does not expect them.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import functools
 import logging
 import os
@@ -15,7 +14,6 @@ from pip._internal.cache import WheelCache
 from pip._internal.exceptions import ResolutionTooDeepError
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.operations.prepare import RequirementPreparer
-from pip._internal.req.constructors import install_req_extend_extras
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.req.req_set import RequirementSet
 from pip._internal.resolution.base import BaseResolver, InstallRequirementProvider
@@ -24,7 +22,6 @@ from pip._internal.resolution.resolvelib.reporter import (
     PipDebuggingReporter,
     PipReporter,
 )
-from pip._internal.utils.packaging import get_requirement
 
 from .base import Candidate, Requirement
 from .factory import Factory
@@ -110,24 +107,12 @@ class Resolver(BaseResolver):
             raise ResolutionTooDeepError from None
 
         req_set = RequirementSet(check_supported_wheels=check_supported_wheels)
-        # process candidates with extras last to ensure their base equivalent is
-        # already in the req_set if appropriate.
-        # Python's sort is stable so using a binary key function keeps relative order
-        # within both subsets.
-        for candidate in sorted(
-            result.mapping.values(), key=lambda c: c.name != c.project_name
-        ):
+        # Each resolved node carries its requested extras (extras are an attribute
+        # of the candidate), so its install requirement already reflects them and
+        # candidates can be processed in any order.
+        for candidate in result.mapping.values():
             ireq = candidate.get_install_requirement()
             if ireq is None:
-                if candidate.name != candidate.project_name:
-                    # extend existing req's extras
-                    with contextlib.suppress(KeyError):
-                        req = req_set.get_requirement(candidate.project_name)
-                        req_set.add_named_requirement(
-                            install_req_extend_extras(
-                                req, get_requirement(candidate.name).extras
-                            )
-                        )
                 continue
 
             # Check if there is already an installation under the same name,

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -2,11 +2,92 @@ from __future__ import annotations
 
 import functools
 import logging
+from collections.abc import Set as AbstractSet
 
 from pip._vendor.packaging import specifiers, version
+from pip._vendor.packaging._parser import MarkerList, Variable
+from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
+from pip._vendor.packaging.utils import canonicalize_name
 
 logger = logging.getLogger(__name__)
+
+
+def _marker_leaf_extra(node: object) -> str | None:
+    """If a marker AST leaf compares the ``extra`` variable, return the
+    canonicalized name it is compared against, otherwise ``None``."""
+    if not isinstance(node, tuple):
+        return None
+    lhs, _op, rhs = node
+    if isinstance(lhs, Variable) and lhs.value == "extra":
+        return canonicalize_name(rhs.value)
+    if isinstance(rhs, Variable) and rhs.value == "extra":
+        return canonicalize_name(lhs.value)
+    return None
+
+
+def _evaluate_marker_against_extras(
+    markers: MarkerList, extras: AbstractSet[str]
+) -> bool:
+    """Evaluate a parsed marker tree, resolving every ``extra`` comparison
+    against the *whole* set of requested ``extras`` rather than a single value.
+
+    ``extra == "x"`` is treated as ``"x" in extras`` and ``extra != "x"`` as
+    ``"x" not in extras``; any other operator on ``extra`` evaluates to ``False``
+    per the dependency-specifiers specification. Comparisons that do not involve
+    ``extra`` are delegated to packaging's normal evaluator against the current
+    environment.
+    """
+    groups: list[list[bool]] = [[]]
+    for marker in markers:
+        if isinstance(marker, list):
+            groups[-1].append(_evaluate_marker_against_extras(marker, extras))
+        elif isinstance(marker, tuple):
+            name = _marker_leaf_extra(marker)
+            if name is not None:
+                op = marker[1].value
+                if op == "==":
+                    groups[-1].append(name in extras)
+                elif op == "!=":
+                    groups[-1].append(name not in extras)
+                else:
+                    # Other operators on ``extra`` are undefined; per the
+                    # dependency-specifiers spec, tools should treat them as
+                    # False.
+                    groups[-1].append(False)
+            else:
+                groups[-1].append(Marker._from_markers([marker]).evaluate())
+        elif marker == "or":
+            groups.append([])
+        # "and" joins within the current group and needs no handling.
+    return any(all(group) for group in groups)
+
+
+def _markers_reference_extra(markers: MarkerList) -> bool:
+    for marker in markers:
+        if isinstance(marker, list):
+            if _markers_reference_extra(marker):
+                return True
+        elif isinstance(marker, tuple) and _marker_leaf_extra(marker) is not None:
+            return True
+    return False
+
+
+def marker_references_extra(marker: Marker) -> bool:
+    """Return whether ``marker`` compares against the ``extra`` variable."""
+    return _markers_reference_extra(marker._markers)
+
+
+def evaluate_marker_with_extras(marker: Marker, extras: AbstractSet[str]) -> bool:
+    """Evaluate ``marker`` treating ``extra`` comparisons as set membership
+    against ``extras`` (the full set of extras requested for the package).
+
+    An empty ``extras`` set corresponds to a package requested without any
+    extras; ``extra != "x"`` then evaluates ``True`` and ``extra == "x"``
+    evaluates ``False``, matching the base (no-extra) install.
+    """
+    normalized = frozenset(canonicalize_name(e) for e in extras if e)
+    return _evaluate_marker_against_extras(marker._markers, normalized)
 
 
 @functools.lru_cache(maxsize=32)

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -264,6 +264,131 @@ def test_new_resolver_installs_extras_warn_missing(script: PipTestEnvironment) -
     script.assert_installed(base="0.1.0", dep="0.1.0")
 
 
+@pytest.mark.parametrize(
+    "to_install, expected, absent",
+    [
+        ("pkg", {"pkg": "1.0", "default_dep": "1.0"}, "gpu_dep"),
+        ("pkg[gpu]", {"pkg": "1.0", "gpu_dep": "1.0"}, "default_dep"),
+    ],
+)
+def test_new_resolver_extra_not_equal_marker(
+    script: PipTestEnvironment,
+    to_install: str,
+    expected: dict[str, str],
+    absent: str,
+) -> None:
+    """A dependency guarded by ``extra != "x"`` is installed unless the ``x``
+    extra is requested, and is dropped when it is (pypa/pip#14139)."""
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "1.0",
+        depends=['default_dep; extra != "gpu"'],
+        extras={"gpu": ["gpu_dep"]},
+    )
+    create_basic_wheel_for_package(script, "default_dep", "1.0")
+    create_basic_wheel_for_package(script, "gpu_dep", "1.0")
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        to_install,
+    )
+    script.assert_installed(**expected)
+    script.assert_not_installed(absent)
+
+
+def test_new_resolver_extra_not_equal_marker_merges_extras(
+    script: PipTestEnvironment,
+) -> None:
+    """When a project is requested both plainly and with an extra, the extras
+    are merged, so an ``extra != "x"`` dependency is dropped when any request
+    activates ``x`` (pypa/pip#14139)."""
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "1.0",
+        depends=['default_dep; extra != "gpu"'],
+        extras={"gpu": ["gpu_dep"]},
+    )
+    create_basic_wheel_for_package(script, "default_dep", "1.0")
+    create_basic_wheel_for_package(script, "gpu_dep", "1.0")
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg",
+        "pkg[gpu]",
+    )
+    script.assert_installed(pkg="1.0", gpu_dep="1.0")
+    script.assert_not_installed("default_dep")
+
+
+def test_new_resolver_extra_not_equal_marker_transitive_request(
+    script: PipTestEnvironment,
+) -> None:
+    """A default-only dependency gated on ``extra != "gpu"`` (here unsatisfiable)
+    does not fail resolution when ``gpu`` is requested only transitively: the
+    resolver prefers the extra-requester so ``pkg``'s merged extras are known
+    before it is decided (pypa/pip#14139)."""
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "1.0",
+        depends=['unsatisfiable>=2; extra != "gpu"'],
+        extras={"gpu": ["gpu_dep"]},
+    )
+    # Only 1.0 exists, so the default-only dependency cannot be satisfied.
+    create_basic_wheel_for_package(script, "unsatisfiable", "1.0")
+    create_basic_wheel_for_package(script, "gpu_dep", "1.0")
+    create_basic_wheel_for_package(script, "wants_gpu", "1.0", depends=["pkg[gpu]"])
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg",
+        "wants_gpu",
+    )
+    script.assert_installed(pkg="1.0", gpu_dep="1.0", wants_gpu="1.0")
+    script.assert_not_installed("unsatisfiable")
+
+
+def test_new_resolver_upgrade_requested_with_extra(
+    script: PipTestEnvironment,
+) -> None:
+    """``pip install --upgrade foo[extra]`` upgrades foo. The request carries an
+    extra, but the resolver keys user-requested packages by their bare name."""
+    create_basic_wheel_for_package(script, "pkg", "1.0", extras={"ext": []})
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[ext]==1.0",
+    )
+    create_basic_wheel_for_package(script, "pkg", "2.0", extras={"ext": []})
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "--upgrade",
+        "pkg[ext]",
+    )
+    script.assert_installed(pkg="2.0")
+
+
 def test_new_resolver_installed_message(script: PipTestEnvironment) -> None:
     create_basic_wheel_for_package(script, "A", "1.0")
     result = script.pip(
@@ -2476,6 +2601,31 @@ def test_new_resolver_constraint_on_link_with_extra(
     script.assert_installed(pkg="1.0")
 
 
+def test_new_resolver_url_constraint_with_extra_request(
+    script: PipTestEnvironment,
+) -> None:
+    """A URL constraint provides the base candidate for a package requested with
+    an extra, so that candidate must be offered carrying the extra."""
+    wheel: pathlib.Path = create_basic_wheel_for_package(
+        script, "pkg", "1.0", extras={"ext": ["ext_dep"]}
+    )
+    create_basic_wheel_for_package(script, "ext_dep", "1.0")
+    constraints = script.scratch_path / "constraints.txt"
+    constraints.write_text(f"pkg @ {wheel.as_uri()}\n")
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "-c",
+        str(constraints),
+        "pkg[ext]",
+    )
+    script.assert_installed(pkg="1.0", ext_dep="1.0")
+
+
 def test_new_resolver_constraint_on_link_with_extra_indirect(
     script: PipTestEnvironment,
 ) -> None:
@@ -2567,4 +2717,29 @@ def test_new_resolver_comes_from_with_extra(
     )
     assert "(from pkg[ext])" in result.stdout
     assert "(from pkg)" not in result.stdout
+    script.assert_installed(pkg="1.0", dep="1.0")
+
+
+def test_new_resolver_comes_from_with_extra_and_version(
+    script: PipTestEnvironment,
+) -> None:
+    """The provenance chain names the extra exactly once, even with a version
+    specifier: it must not duplicate the pkg[ext]==x hop."""
+    create_basic_wheel_for_package(script, "dep", "1.0")
+    create_basic_wheel_for_package(script, "pkg", "1.0", extras={"ext": ["dep"]})
+    req_path = script.scratch_path / "reqs.txt"
+    req_path.write_text("pkg[ext]==1.0")
+
+    result = script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "-r",
+        str(req_path),
+    )
+
+    assert "(from pkg[ext]==1.0->pkg[ext]==1.0" not in result.stdout, result.stdout
+    assert "(from pkg[ext]==1.0->-r" in result.stdout
     script.assert_installed(pkg="1.0", dep="1.0")

--- a/tests/unit/resolution_resolvelib/test_provider.py
+++ b/tests/unit/resolution_resolvelib/test_provider.py
@@ -63,7 +63,7 @@ def build_explicit_req_info(
             {"pinned-package": [build_req_info("pinned-package==1.0")]},
             [],
             {},
-            (True, True, False, True, math.inf, False, "pinned-package"),
+            (True, True, False, True, False, math.inf, False, "pinned-package"),
         ),
         # Star-specified package, i.e. with "*"
         (
@@ -71,7 +71,7 @@ def build_explicit_req_info(
             {"star-specified-package": [build_req_info("star-specified-package==1.*")]},
             [],
             {},
-            (True, True, True, False, math.inf, False, "star-specified-package"),
+            (True, True, True, False, False, math.inf, False, "star-specified-package"),
         ),
         # Package that caused backtracking
         (
@@ -79,7 +79,7 @@ def build_explicit_req_info(
             {"backtrack-package": [build_req_info("backtrack-package")]},
             [build_req_info("backtrack-package")],
             {},
-            (True, True, True, True, math.inf, True, "backtrack-package"),
+            (True, True, True, True, False, math.inf, True, "backtrack-package"),
         ),
         # Root package requested by user
         (
@@ -87,7 +87,7 @@ def build_explicit_req_info(
             {"root-package": [build_req_info("root-package")]},
             [],
             {"root-package": 1},
-            (True, True, True, True, 1, True, "root-package"),
+            (True, True, True, True, False, 1, True, "root-package"),
         ),
         # Unfree package (with specifier operator)
         (
@@ -95,7 +95,7 @@ def build_explicit_req_info(
             {"unfree-package": [build_req_info("unfree-package!=1")]},
             [],
             {},
-            (True, True, True, True, math.inf, False, "unfree-package"),
+            (True, True, True, True, False, math.inf, False, "unfree-package"),
         ),
         # Free package (no operator)
         (
@@ -103,7 +103,7 @@ def build_explicit_req_info(
             {"free-package": [build_req_info("free-package")]},
             [],
             {},
-            (True, True, True, True, math.inf, True, "free-package"),
+            (True, True, True, True, False, math.inf, True, "free-package"),
         ),
         # Test case for "direct" preference (explicit URL)
         (
@@ -111,7 +111,7 @@ def build_explicit_req_info(
             {"direct-package": [build_explicit_req_info("direct-package")]},
             [],
             {},
-            (True, False, True, True, math.inf, True, "direct-package"),
+            (True, False, True, True, False, math.inf, True, "direct-package"),
         ),
         # Upper bounded with <= operator
         (
@@ -123,7 +123,16 @@ def build_explicit_req_info(
             },
             [],
             {},
-            (True, True, True, False, math.inf, False, "upper-bound-lte-package"),
+            (
+                True,
+                True,
+                True,
+                False,
+                False,
+                math.inf,
+                False,
+                "upper-bound-lte-package",
+            ),
         ),
         # Upper bounded with < operator
         (
@@ -131,7 +140,7 @@ def build_explicit_req_info(
             {"upper-bound-lt-package": [build_req_info("upper-bound-lt-package<2.0")]},
             [],
             {},
-            (True, True, True, False, math.inf, False, "upper-bound-lt-package"),
+            (True, True, True, False, False, math.inf, False, "upper-bound-lt-package"),
         ),
         # Upper bounded with ~= operator
         (
@@ -148,6 +157,7 @@ def build_explicit_req_info(
                 True,
                 True,
                 False,
+                False,
                 math.inf,
                 False,
                 "upper-bound-compatible-package",
@@ -159,7 +169,7 @@ def build_explicit_req_info(
             {"lower-bound-package": [build_req_info("lower-bound-package>=1.0")]},
             [],
             {},
-            (True, True, True, True, math.inf, False, "lower-bound-package"),
+            (True, True, True, True, False, math.inf, False, "lower-bound-package"),
         ),
     ],
 )
@@ -184,6 +194,26 @@ def test_get_preference(
     )
 
     assert preference == expected, f"Expected {expected}, got {preference}"
+
+
+def test_get_preference_defers_extra_removable(factory: Factory) -> None:
+    """A package with a dependency an extra can remove is deprioritized, so a
+    transitively-requested extra is discovered before the package is decided."""
+    factory._extra_removable_packages["defer-package"] = True
+    provider = PipProvider(
+        factory=factory,
+        constraints={},
+        ignore_dependencies=False,
+        upgrade_strategy="to-satisfy-only",
+        user_requested={},
+    )
+
+    information = {"defer-package": [build_req_info("defer-package")]}
+    preference = provider.get_preference("defer-package", {}, {}, information, [])
+
+    # The defer_for_extras element (index 4) is True; it is False for a package
+    # without extra-removable dependencies.
+    assert preference[4] is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Placeholder: add "Fixes #14139" when this is opened against pypa/pip. -->

`extra` environment markers on dependencies are now evaluated against the full
set of extras requested for a package:

- `extra == "name"` behaves like `"name" in extras`
- `extra != "name"` behaves like `"name" not in extras`
- other operators on `extra` evaluate as false

Previously `extra != "name"` was always treated as active, so a dependency
guarded by it (e.g. `onnxruntime; extra != "gpu"`) was installed even when the
`gpu` extra was requested.

Extras are modelled as an attribute of one resolver node, so `foo` and
`foo[gpu]` resolve as a single package against the merged set of requested
extras. Marker evaluation is shared by the metadata layer, `match_markers`, and
the post-install consistency check.

A package can still be decided before a transitively-requested `pkg[extra]` is
discovered. A best-effort preference nudge resolves a package whose dependencies
an extra can remove after other packages, which handles the common transitive
cases; it is not a guarantee.

Tests: full `tests/unit`, `tests/functional/test_new_resolver.py` (with new
`extra != "..."` single/merged/transitive/upgrade/constraint cases), and the
`pip check` tests.
