### PR TITLE
Model extras as a single resolver node

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -102,6 +102,11 @@ class Requirement:
         """
         raise NotImplementedError("Subclass should override")
 
+    @property
+    def extras(self) -> frozenset[NormalizedName]:
+        """The extras this requirement asks of its project."""
+        return frozenset()
+
     def is_satisfied_by(self, candidate: Candidate) -> bool:
         return False
 
@@ -137,6 +142,23 @@ class Candidate:
         extras, where ``project_name`` would not contain the ``[...]`` part.
         """
         raise NotImplementedError("Override in subclass")
+
+    @property
+    def base_candidate(self) -> Candidate:
+        """The underlying installation candidate.
+
+        Itself for a plain candidate; an ``ExtrasCandidate`` returns the
+        candidate it wraps.
+        """
+        return self
+
+    @property
+    def extras(self) -> frozenset[NormalizedName]:
+        """The extras requested for this candidate.
+
+        Empty for a plain candidate; an ``ExtrasCandidate`` returns its extras.
+        """
+        return frozenset()
 
     @property
     def version(self) -> Version:

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -21,6 +21,7 @@ from pip._internal.metadata import BaseDistribution
 from pip._internal.models.link import Link, links_equivalent
 from pip._internal.models.wheel import Wheel
 from pip._internal.req.constructors import (
+    install_req_extend_extras,
     install_req_from_editable,
     install_req_from_line,
 )
@@ -305,9 +306,9 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
             # Version may not be present for PEP 508 direct URLs
             if version is not None:
                 wheel_version = Version(wheel.version)
-                assert (
-                    version == wheel_version
-                ), f"{version!r} != {wheel_version!r} for wheel {name}"
+                assert version == wheel_version, (
+                    f"{version!r} != {wheel_version!r} for wheel {name}"
+                )
 
         if cache_entry is not None:
             assert ireq.link.is_wheel
@@ -433,28 +434,13 @@ class AlreadyInstalledCandidate(Candidate):
 
 
 class ExtrasCandidate(Candidate):
-    """A candidate that has 'extras', indicating additional dependencies.
+    """A base candidate wrapped with a set of requested extras.
 
-    Requirements can be for a project with dependencies, something like
-    foo[extra].  The extras don't affect the project/version being installed
-    directly, but indicate that we need additional dependencies. We model that
-    by having an artificial ExtrasCandidate that wraps the "base" candidate.
-
-    The ExtrasCandidate differs from the base in the following ways:
-
-    1. It has a unique name, of the form foo[extra]. This causes the resolver
-       to treat it as a separate node in the dependency graph.
-    2. When we're getting the candidate's dependencies,
-       a) We specify that we want the extra dependencies as well.
-       b) We add a dependency on the base candidate.
-          See below for why this is needed.
-    3. We return None for the underlying InstallRequirement, as the base
-       candidate will provide it, and we don't want to end up with duplicates.
-
-    The dependency on the base candidate is needed so that the resolver can't
-    decide that it should recommend foo[extra1] version 1.0 and foo[extra2]
-    version 2.0. Having those candidates depend on foo=1.0 and foo=2.0
-    respectively forces the resolver to recognise that this is a conflict.
+    Requirements can ask for a project together with extras, like foo[extra].
+    Extras don't change the project or version installed, only which
+    dependencies are pulled in, so they are modelled as an attribute of the
+    candidate: identify() returns the bare project name, so foo and foo[extra]
+    resolve as one node against the merged set of requested extras.
     """
 
     def __init__(
@@ -473,8 +459,12 @@ class ExtrasCandidate(Candidate):
             it does not do any leg work.
         """
         self.base = base
-        self.extras = frozenset(canonicalize_name(e) for e in extras)
-        self._comes_from = comes_from if comes_from is not None else self.base._ireq
+        self._extras = frozenset(canonicalize_name(e) for e in extras)
+
+        # Name the requested extras in the provenance chain (e.g. "(from
+        # pkg[extra])"), even when created from a plain requirement.
+        base_comes_from = comes_from if comes_from is not None else self.base._ireq
+        self._comes_from = install_req_extend_extras(base_comes_from, self.extras)
 
     def __str__(self) -> str:
         name, rest = str(self.base).split(" ", 1)
@@ -490,6 +480,14 @@ class ExtrasCandidate(Candidate):
         if isinstance(other, self.__class__):
             return self.base == other.base and self.extras == other.extras
         return False
+
+    @property
+    def base_candidate(self) -> Candidate:
+        return self.base
+
+    @property
+    def extras(self) -> frozenset[NormalizedName]:
+        return self._extras
 
     @property
     def project_name(self) -> NormalizedName:
@@ -524,9 +522,8 @@ class ExtrasCandidate(Candidate):
     def iter_dependencies(self, with_requires: bool) -> Iterable[Requirement | None]:
         factory = self.base._factory
 
-        # Add a dependency on the exact base
-        # (See note 2b in the class docstring)
-        yield factory.make_requirement_from_candidate(self.base)
+        # Depend on the base's Requires-Python.
+        yield factory.make_requires_python_requirement(self.base.dist.requires_python)
         if not with_requires:
             return
 
@@ -550,10 +547,12 @@ class ExtrasCandidate(Candidate):
             )
 
     def get_install_requirement(self) -> InstallRequirement | None:
-        # We don't return anything here, because we always
-        # depend on the base candidate, and we'll get the
-        # install requirement from that.
-        return None
+        # Install the base, with the requested extras recorded on the
+        # requirement.
+        base_ireq = self.base.get_install_requirement()
+        if base_ireq is None:
+            return None
+        return install_req_extend_extras(base_ireq, self.extras)
 
 
 class RequiresPythonCandidate(Candidate):

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import copy
 import functools
 import logging
@@ -13,7 +12,6 @@ from typing import (
     cast,
 )
 
-from pip._vendor.packaging.requirements import InvalidRequirement
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 from pip._vendor.packaging.version import InvalidVersion, Version
@@ -47,7 +45,6 @@ from pip._internal.req.req_install import (
 from pip._internal.resolution.base import InstallRequirementProvider
 from pip._internal.utils.compatibility_tags import get_supported
 from pip._internal.utils.hashes import Hashes
-from pip._internal.utils.packaging import get_requirement
 from pip._internal.utils.virtualenv import running_under_virtualenv
 
 from .base import Candidate, Constraint, Requirement
@@ -141,7 +138,7 @@ class Factory:
         msg = f"{link.filename} is not a supported wheel on this platform."
         raise UnsupportedWheel(msg)
 
-    def _make_extras_candidate(
+    def make_extras_candidate(
         self,
         base: BaseCandidate,
         extras: frozenset[str],
@@ -161,6 +158,7 @@ class Factory:
         dist: BaseDistribution,
         extras: frozenset[str],
         template: InstallRequirement,
+        comes_from: InstallRequirement | None = None,
     ) -> Candidate:
         try:
             base = self._installed_candidate_cache[dist.canonical_name]
@@ -169,7 +167,9 @@ class Factory:
             self._installed_candidate_cache[dist.canonical_name] = base
         if not extras:
             return base
-        return self._make_extras_candidate(base, extras, comes_from=template)
+        return self.make_extras_candidate(
+            base, extras, comes_from=comes_from if comes_from is not None else template
+        )
 
     def _make_candidate_from_link(
         self,
@@ -178,13 +178,18 @@ class Factory:
         template: InstallRequirement,
         name: NormalizedName | None,
         version: Version | None,
+        comes_from: InstallRequirement | None = None,
     ) -> Candidate | None:
         base: BaseCandidate | None = self._make_base_candidate_from_link(
             link, template, name, version
         )
-        if not extras or base is None:
+        if base is None:
+            return None
+        if not extras:
             return base
-        return self._make_extras_candidate(base, extras, comes_from=template)
+        return self.make_extras_candidate(
+            base, extras, comes_from=comes_from if comes_from is not None else template
+        )
 
     def _make_base_candidate_from_link(
         self,
@@ -305,6 +310,10 @@ class Factory:
             hashes &= ireq.hashes(trust_internet=False)
             extras |= frozenset(ireq.extras)
 
+        # Prefer an extras-carrying requirement for the "(from pkg[extra])"
+        # provenance chain; the extras-dropped template would double the hop.
+        comes_from = next((ireq for ireq in ireqs if ireq.extras), template)
+
         def _get_installed_candidate() -> Candidate | None:
             """Get the candidate for the currently-installed version."""
             # If --force-reinstall is set, we want the version from the index
@@ -328,6 +337,7 @@ class Factory:
                 dist=installed_dist,
                 extras=extras,
                 template=template,
+                comes_from=comes_from,
             )
             # The candidate is a known incompatibility. Don't use it.
             if id(candidate) in incompatible_ids:
@@ -379,6 +389,7 @@ class Factory:
                     template=template,
                     name=name,
                     version=ican.version,
+                    comes_from=comes_from,
                 )
                 yield ican.version, func
 
@@ -389,60 +400,27 @@ class Factory:
             incompatible_ids,
         )
 
-    def _iter_explicit_candidates_from_base(
-        self,
-        base_requirements: Iterable[Requirement],
-        extras: frozenset[str],
-    ) -> Iterator[Candidate]:
-        """Produce explicit candidates from the base given an extra-ed package.
-
-        :param base_requirements: Requirements known to the resolver. The
-            requirements are guaranteed to not have extras.
-        :param extras: The extras to inject into the explicit requirements'
-            candidates.
-        """
-        for req in base_requirements:
-            lookup_cand, _ = req.get_candidate_lookup()
-            if lookup_cand is None:  # Not explicit.
-                continue
-            # We've stripped extras from the identifier, and should always
-            # get a BaseCandidate here, unless there's a bug elsewhere.
-            base_cand = as_base_candidate(lookup_cand)
-            assert base_cand is not None, "no extras here"
-            yield self._make_extras_candidate(base_cand, extras)
-
     def _iter_candidates_from_constraints(
         self,
         identifier: str,
         constraint: Constraint,
         template: InstallRequirement,
     ) -> Iterator[Candidate]:
-        """Produce explicit candidates from constraints.
+        """Produce base candidates from a constraint's links.
 
         This creates "fake" InstallRequirement objects that are basically clones
-        of what "should" be the template, but with original_link set to link.
+        of what "should" be the template, but with original_link set to link. Any
+        requested extras are applied by find_candidates, not here.
         """
-        extras: frozenset[str] = frozenset()
-        base_identifier = identifier
-        with contextlib.suppress(InvalidRequirement):
-            parsed_requirement = get_requirement(identifier)
-            if parsed_requirement.name != identifier:
-                base_identifier = canonicalize_name(parsed_requirement.name)
-                extras = frozenset(parsed_requirement.extras)
-
         for link in constraint.links:
             self._fail_if_link_is_unsupported_wheel(link)
             base_candidate = self._make_base_candidate_from_link(
                 link,
                 template=install_req_from_link_and_ireq(link, template),
-                name=canonicalize_name(base_identifier),
+                name=canonicalize_name(identifier),
                 version=None,
             )
-            if base_candidate is None:
-                continue
-            if extras:
-                yield self._make_extras_candidate(base_candidate, extras)
-            else:
+            if base_candidate is not None:
                 yield base_candidate
 
     def find_candidates(
@@ -464,22 +442,6 @@ class Factory:
             if ireq is not None:
                 ireqs.append(ireq)
 
-        # If the current identifier contains extras, add requires and explicit
-        # candidates from entries from extra-less identifier.
-        with contextlib.suppress(InvalidRequirement):
-            parsed_requirement = get_requirement(identifier)
-            if parsed_requirement.name != identifier:
-                explicit_candidates.update(
-                    self._iter_explicit_candidates_from_base(
-                        requirements.get(parsed_requirement.name, ()),
-                        frozenset(parsed_requirement.extras),
-                    ),
-                )
-                for req in requirements.get(parsed_requirement.name, []):
-                    _, ireq = req.get_candidate_lookup()
-                    if ireq is not None:
-                        ireqs.append(ireq)
-
         # Add explicit candidates from constraints. We only do this if there are
         # known ireqs, which represent requirements not already explicit. If
         # there are no ireqs, we're constraining already-explicit requirements,
@@ -497,6 +459,23 @@ class Factory:
                 # If we're constrained to install a wheel incompatible with the
                 # target architecture, no candidates will ever be valid.
                 return ()
+
+        # Also offer every explicit base candidate carrying the requested extras,
+        # so one candidate satisfies both a plain and an extras requirement on it.
+        # After the constraints block so constraint candidates are wrapped too.
+        requested_extras: frozenset[NormalizedName] = frozenset()
+        for ireq in ireqs:
+            requested_extras |= frozenset(canonicalize_name(e) for e in ireq.extras)
+        for cand in explicit_candidates:
+            requested_extras |= cand.extras
+
+        if requested_extras:
+            for cand in list(explicit_candidates):
+                base_cand = as_base_candidate(cand)
+                if base_cand is not None:
+                    explicit_candidates.add(
+                        self.make_extras_candidate(base_cand, requested_extras)
+                    )
 
         # Since we cache all the candidates, incompatibility identification
         # can be made quicker by comparing only the id() values.
@@ -567,12 +546,13 @@ class Factory:
                     raise self._build_failures[ireq.link]
                 yield UnsatisfiableRequirement(canonicalize_name(ireq.name))
             else:
-                # require the base from the link
+                # Register the base link candidate under the bare identifier so
+                # other requirements on the project can resolve to it.
                 yield self.make_requirement_from_candidate(cand)
                 if ireq.extras:
-                    # require the extras on top of the base candidate
+                    # Also offer the base wrapped with the requested extras.
                     yield self.make_requirement_from_candidate(
-                        self._make_extras_candidate(cand, frozenset(ireq.extras))
+                        self.make_extras_candidate(cand, frozenset(ireq.extras))
                     )
 
     def collect_root_requirements(
@@ -603,8 +583,13 @@ class Factory:
                 if not reqs:
                     continue
                 template = reqs[0]
-                if ireq.user_supplied and template.name not in collected.user_requested:
-                    collected.user_requested[template.name] = i
+
+                # Key user_requested on project_name, matching identify(): a
+                # user-supplied foo[extra] registers under foo, else its upgrade
+                # eligibility and requested ordering are lost.
+                name = template.project_name
+                if ireq.user_supplied and name not in collected.user_requested:
+                    collected.user_requested[name] = i
                 collected.requirements.extend(reqs)
         # Put requirements with extras at the end of the root requires. This does not
         # affect resolvelib's picking preference but it does affect its initial criteria

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable, Iterator, Mapping, Sequence
 from functools import cache
 from typing import (
     TYPE_CHECKING,
-    TypeVar,
 )
 
 from pip._vendor.resolvelib.providers import AbstractProvider
@@ -49,35 +48,6 @@ _CONFLICT_PRIORITY_THRESHOLD = 5
 # services to those objects (access to pip's finder and preparer).
 
 
-D = TypeVar("D")
-V = TypeVar("V")
-
-
-def _get_with_identifier(
-    mapping: Mapping[str, V],
-    identifier: str,
-    default: D,
-) -> D | V:
-    """Get item from a package name lookup mapping with a resolver identifier.
-
-    This extra logic is needed when the target mapping is keyed by package
-    name, which cannot be directly looked up with an identifier (which may
-    contain requested extras). Additional logic is added to also look up a value
-    by "cleaning up" the extras from the identifier.
-    """
-    if identifier in mapping:
-        return mapping[identifier]
-    # HACK: Theoretically we should check whether this identifier is a valid
-    # "NAME[EXTRAS]" format, and parse out the name part with packaging or
-    # some regular expression. But since pip's resolver only spits out three
-    # kinds of identifiers: normalized PEP 503 names, normalized names plus
-    # extras, and Requires-Python, we can cheat a bit here.
-    name, open_bracket, _ = identifier.partition("[")
-    if open_bracket and name in mapping:
-        return mapping[name]
-    return default
-
-
 class PipProvider(_ProviderBase):
     """Pip's provider implementation for resolvelib.
 
@@ -115,7 +85,9 @@ class PipProvider(_ProviderBase):
         return self._constraints
 
     def identify(self, requirement_or_candidate: Requirement | Candidate) -> str:
-        return requirement_or_candidate.name
+        # foo and foo[extra] share one identity; extras are an attribute of the
+        # candidate (see ExtrasCandidate).
+        return requirement_or_candidate.project_name
 
     def narrow_requirement_selection(
         self,
@@ -139,11 +111,13 @@ class PipProvider(_ProviderBase):
               get promoted so they are resolved earlier. This lets their
               constraints take effect before other packages pick a version.
         """
+        # Key on project_name, matching identify(): a foo[extra] requirement or
+        # parent must count against foo.
         backtrack_identifiers = set()
         for info in backtrack_causes:
-            names = [info.requirement.name]
+            names = [info.requirement.project_name]
             if info.parent is not None:
-                names.append(info.parent.name)
+                names.append(info.parent.project_name)
             for name in names:
                 backtrack_identifiers.add(name)
                 if name not in resolutions:
@@ -273,18 +247,12 @@ class PipProvider(_ProviderBase):
             if self._upgrade_strategy == "eager":
                 return True
             elif self._upgrade_strategy == "only-if-needed":
-                user_order = _get_with_identifier(
-                    self._user_requested,
-                    identifier,
-                    default=None,
-                )
-                return user_order is not None
+                return identifier in self._user_requested
             return False
 
-        constraint = _get_with_identifier(
-            self._constraints,
+        constraint = self._constraints.get(
             identifier,
-            default=Constraint.empty(),
+            Constraint.empty(),
         )
         return self._factory.find_candidates(
             identifier=identifier,

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -39,6 +39,10 @@ class ExplicitRequirement(Requirement):
         # No need to canonicalize - the candidate did this
         return self.candidate.name
 
+    @property
+    def extras(self) -> frozenset[NormalizedName]:
+        return self.candidate.extras
+
     def format_for_error(self) -> str:
         return self.candidate.format_for_error()
 
@@ -46,7 +50,13 @@ class ExplicitRequirement(Requirement):
         return self.candidate, None
 
     def is_satisfied_by(self, candidate: Candidate) -> bool:
-        return candidate == self.candidate
+        if candidate == self.candidate:
+            return True
+        # A candidate that wraps the required one with more extras also
+        # satisfies it (extras only add dependencies).
+        if candidate.base_candidate != self.candidate.base_candidate:
+            return False
+        return self.candidate.extras <= candidate.extras
 
 
 class SpecifierRequirement(Requirement):
@@ -92,6 +102,10 @@ class SpecifierRequirement(Requirement):
     def name(self) -> str:
         return format_name(self.project_name, self._extras)
 
+    @property
+    def extras(self) -> frozenset[NormalizedName]:
+        return self._extras
+
     def format_for_error(self) -> str:
         # Convert comma-separated specifiers into "A, B, ..., F and G"
         # This makes the specifier a bit more "human readable", without
@@ -109,10 +123,14 @@ class SpecifierRequirement(Requirement):
         return None, self._ireq
 
     def is_satisfied_by(self, candidate: Candidate) -> bool:
-        assert candidate.name == self.name, (
+        assert candidate.project_name == self.project_name, (
             f"Internal issue: Candidate is not for this requirement "
-            f"{candidate.name} vs {self.name}"
+            f"{candidate.project_name} vs {self.project_name}"
         )
+        # The candidate must provide every requested extra; carrying more still
+        # satisfies (extras only add dependencies).
+        if not self._extras <= candidate.extras:
+            return False
         # We can safely always allow prereleases here since PackageFinder
         # already implements the prerelease logic, and would have filtered out
         # prerelease candidates if the user does not expect them.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import contextlib
 import functools
 import logging
 import os
+from collections import defaultdict, deque
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, cast
 
-from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 from pip._vendor.resolvelib import BaseReporter, ResolutionImpossible, ResolutionTooDeep
 from pip._vendor.resolvelib import Resolver as RLResolver
 from pip._vendor.resolvelib.structs import DirectedGraph
@@ -15,7 +16,6 @@ from pip._internal.cache import WheelCache
 from pip._internal.exceptions import ResolutionTooDeepError
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.operations.prepare import RequirementPreparer
-from pip._internal.req.constructors import install_req_extend_extras
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.req.req_set import RequirementSet
 from pip._internal.resolution.base import BaseResolver, InstallRequirementProvider
@@ -24,9 +24,9 @@ from pip._internal.resolution.resolvelib.reporter import (
     PipDebuggingReporter,
     PipReporter,
 )
-from pip._internal.utils.packaging import get_requirement
 
 from .base import Candidate, Requirement
+from .candidates import as_base_candidate
 from .factory import Factory
 
 if TYPE_CHECKING:
@@ -109,25 +109,34 @@ class Resolver(BaseResolver):
         except ResolutionTooDeep:
             raise ResolutionTooDeepError from None
 
+        # Extras are an attribute of a single resolver node, so a project stays
+        # pinned with an extra even after the requirement that asked for it is
+        # backtracked away, leaving that extra's dependencies stranded in the
+        # mapping. Re-derive which extras each project still needs, and skip the
+        # stranded nodes, so the install set matches what the solution requires.
+        required_extras = self._reachable_extras(result, collected.requirements)
+
         req_set = RequirementSet(check_supported_wheels=check_supported_wheels)
-        # process candidates with extras last to ensure their base equivalent is
-        # already in the req_set if appropriate.
-        # Python's sort is stable so using a binary key function keeps relative order
-        # within both subsets.
-        for candidate in sorted(
-            result.mapping.values(), key=lambda c: c.name != c.project_name
-        ):
+        for name, pinned in result.mapping.items():
+            extras = required_extras.get(name)
+            if extras is None:
+                # Held only by a stale extra that nothing still requests.
+                continue
+
+            if extras == pinned.extras:
+                candidate: Candidate = pinned
+            else:
+                # The pin carries more extras than survived, so it is an
+                # ExtrasCandidate; install its base under only the extras still
+                # required.
+                base = as_base_candidate(pinned.base_candidate)
+                assert base is not None, "only an ExtrasCandidate can shed extras"
+                candidate = (
+                    self.factory.make_extras_candidate(base, extras) if extras else base
+                )
+
             ireq = candidate.get_install_requirement()
             if ireq is None:
-                if candidate.name != candidate.project_name:
-                    # extend existing req's extras
-                    with contextlib.suppress(KeyError):
-                        req = req_set.get_requirement(candidate.project_name)
-                        req_set.add_named_requirement(
-                            install_req_extend_extras(
-                                req, get_requirement(candidate.name).extras
-                            )
-                        )
                 continue
 
             # Check if there is already an installation under the same name,
@@ -182,6 +191,126 @@ class Resolver(BaseResolver):
             req_set.add_named_requirement(ireq)
 
         return req_set
+
+    def _reachable_extras(
+        self,
+        result: Result,
+        roots: list[Requirement],
+    ) -> dict[str, frozenset[NormalizedName]]:
+        """Map each installable project to the extras it still requires.
+
+        A project stays pinned with an extra even after the requirement that
+        asked for it is backtracked away (see the note in ``resolve``), which
+        strands that extra's dependencies in ``result.mapping``. Walk the
+        solution from the root requirements, following each project's
+        dependencies under only the extras still asked of it; projects the walk
+        never reaches were held solely by a stale extra and are dropped.
+
+        resolvelib already recorded every dependency edge in ``result.criteria``,
+        so the walk reuses those. They are exact unless a project kept an extra
+        no surviving requirement asks for, in which case a recorded edge may
+        belong to that stale extra. That is rare, so it is detected with a cheap
+        check and only then are the dependencies re-derived from scratch.
+        """
+        mapping = result.mapping
+
+        # Without extras nothing is stranded and every pinned node is reachable.
+        if not any(candidate.extras for candidate in mapping.values()):
+            return {name: frozenset() for name in mapping}
+
+        name_of = {id(c): name for name, c in mapping.items()}
+
+        # Invert the criteria into parent -> [(child, requested extras)], keeping
+        # only edges whose parent is still pinned in the final solution.
+        recorded: dict[str, list[tuple[str, frozenset[NormalizedName]]]] = defaultdict(
+            list
+        )
+        for child, criterion in result.criteria.items():
+            if child not in mapping:
+                continue
+            for info in criterion.information:
+                parent = name_of.get(id(info.parent))
+                if parent is not None:
+                    recorded[parent].append((child, info.requirement.extras))
+
+        active = self._walk_required_extras(
+            roots, mapping, lambda name, _extras: recorded.get(name, ())
+        )
+
+        stale = any(
+            frozenset(extras) != mapping[name].extras
+            for name, extras in active.items()
+            if mapping[name].extras
+        )
+        if stale:
+            # A project kept a stale extra, so a recorded edge may belong to it;
+            # re-derive dependencies under only each project's surviving extras.
+            active = self._walk_required_extras(roots, mapping, self._derived_edges)
+
+        return {name: frozenset(extras) for name, extras in active.items()}
+
+    def _walk_required_extras(
+        self,
+        roots: list[Requirement],
+        mapping: dict[str, Candidate],
+        edges_of: Callable[
+            [str, set[NormalizedName]],
+            Iterable[tuple[str, frozenset[NormalizedName]]],
+        ],
+    ) -> dict[str, set[NormalizedName]]:
+        """Propagate requested extras from the roots along ``edges_of``.
+
+        Returns the reached projects mapped to the union of extras asked of them.
+        """
+        active: dict[str, set[NormalizedName]] = {}
+        queue: deque[str] = deque()
+
+        # Record the extras asked of a node, re-queueing it when they grow.
+        def request(name: str, extras: frozenset[NormalizedName]) -> None:
+            reached = active.get(name)
+            if reached is None:
+                active[name] = set(extras)
+                queue.append(name)
+            elif not extras <= reached:
+                reached |= extras
+                queue.append(name)
+
+        for root in roots:
+            if root.project_name in mapping:
+                request(root.project_name, root.extras)
+
+        while queue:
+            name = queue.popleft()
+            for child, child_extras in edges_of(name, active[name]):
+                request(child, child_extras)
+
+        return active
+
+    def _derived_edges(
+        self, name: str, extras: set[NormalizedName]
+    ) -> list[tuple[str, frozenset[NormalizedName]]]:
+        """Recompute a project's in-solution dependencies under ``extras``.
+
+        Used only when a stale extra is present. Extras the project does not
+        provide are dropped: they pull nothing, and re-deriving them would repeat
+        the "does not provide the extra" warning already emitted during resolve.
+        """
+        assert self._result is not None
+        mapping = self._result.mapping
+
+        base = as_base_candidate(mapping[name].base_candidate)
+        if base is None:
+            # The Requires-Python node has no dependencies to contribute.
+            return []
+
+        # Read the dependencies under only the extras the project provides.
+        valid = frozenset(base.dist.iter_provided_extras()) & extras
+        source = self.factory.make_extras_candidate(base, valid) if valid else base
+        return [
+            (dep.project_name, dep.extras)
+            for dep in source.iter_dependencies(not self.ignore_dependencies)
+            if dep is not None and dep.project_name in mapping
+        ]
 
     def get_installation_order(
         self, req_set: RequirementSet

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -264,6 +264,150 @@ def test_new_resolver_installs_extras_warn_missing(script: PipTestEnvironment) -
     script.assert_installed(base="0.1.0", dep="0.1.0")
 
 
+def test_new_resolver_upgrade_requested_with_extra(
+    script: PipTestEnvironment,
+) -> None:
+    """``pip install --upgrade foo[extra]`` upgrades foo. The request carries an
+    extra, but the resolver keys user-requested packages by their bare name."""
+    create_basic_wheel_for_package(script, "pkg", "1.0", extras={"ext": []})
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[ext]==1.0",
+    )
+    create_basic_wheel_for_package(script, "pkg", "2.0", extras={"ext": []})
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "--upgrade",
+        "pkg[ext]",
+    )
+    script.assert_installed(pkg="2.0")
+
+
+@pytest.mark.parametrize("roots", [("srv", "pkg"), ("pkg", "srv")])
+def test_new_resolver_extra_dropped_after_backtracking(
+    script: PipTestEnvironment,
+    roots: tuple[str, str],
+) -> None:
+    """An extra's dependencies are not installed when the requirement that asked
+    for the extra is backtracked away.
+
+    ``srv 2.0`` requires ``pkg[x]`` (which pulls ``xdep``), but ``pkg`` then
+    forces ``srv`` down to ``1.0``, which does not ask for the extra. Once the
+    only requester of ``x`` is gone, ``xdep`` must not be installed. The root
+    order changes which candidate is tried first, so check both.
+    """
+    create_basic_wheel_for_package(script, "xdep", "1.0")
+    create_basic_wheel_for_package(
+        script, "pkg", "1.0", depends=["srv<2"], extras={"x": ["xdep"]}
+    )
+    create_basic_wheel_for_package(script, "srv", "2.0", depends=["pkg[x]"])
+    create_basic_wheel_for_package(script, "srv", "1.0")
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        *roots,
+    )
+    script.assert_installed(pkg="1.0", srv="1.0")
+    script.assert_not_installed("xdep")
+
+
+def test_new_resolver_extra_dropped_after_backtracking_is_transitive(
+    script: PipTestEnvironment,
+) -> None:
+    """Dropping a backtracked-away extra also drops what that extra pulled in
+    transitively, not just its direct dependency."""
+    create_basic_wheel_for_package(script, "xdep_child", "1.0")
+    create_basic_wheel_for_package(script, "xdep", "1.0", depends=["xdep_child"])
+    create_basic_wheel_for_package(
+        script, "pkg", "1.0", depends=["srv<2"], extras={"x": ["xdep"]}
+    )
+    create_basic_wheel_for_package(script, "srv", "2.0", depends=["pkg[x]"])
+    create_basic_wheel_for_package(script, "srv", "1.0")
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "srv",
+        "pkg",
+    )
+    script.assert_installed(pkg="1.0", srv="1.0")
+    script.assert_not_installed("xdep", "xdep_child")
+
+
+def test_new_resolver_extra_kept_when_another_requester_survives(
+    script: PipTestEnvironment,
+) -> None:
+    """The extra's dependencies stay installed when a requirement that survives
+    backtracking still asks for the extra."""
+    create_basic_wheel_for_package(script, "xdep", "1.0")
+    create_basic_wheel_for_package(
+        script, "pkg", "1.0", depends=["srv<2"], extras={"x": ["xdep"]}
+    )
+    create_basic_wheel_for_package(script, "srv", "2.0", depends=["pkg[x]"])
+    create_basic_wheel_for_package(script, "srv", "1.0")
+    create_basic_wheel_for_package(script, "keeper", "1.0", depends=["pkg[x]"])
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "srv",
+        "pkg",
+        "keeper",
+    )
+    script.assert_installed(pkg="1.0", srv="1.0", keeper="1.0", xdep="1.0")
+
+
+@pytest.mark.parametrize("roots", [("srv", "pkg[x]"), ("pkg[x]", "srv")])
+def test_new_resolver_only_backtracked_extra_dropped(
+    script: PipTestEnvironment,
+    roots: tuple[str, str],
+) -> None:
+    """When a package is pinned with two extras and only one requester is
+    backtracked away, just that extra's dependencies are dropped.
+
+    ``srv 2.0`` asks for ``pkg[y]`` while the root asks for ``pkg[x]``, so ``pkg``
+    pins with both extras. ``pkg`` then forces ``srv`` down to ``1.0``, dropping
+    the ``pkg[y]`` requirement; ``x`` survives, so ``xdep`` stays and only
+    ``ydep`` is dropped.
+    """
+    create_basic_wheel_for_package(script, "xdep", "1.0")
+    create_basic_wheel_for_package(script, "ydep", "1.0")
+    create_basic_wheel_for_package(
+        script, "pkg", "1.0", depends=["srv<2"], extras={"x": ["xdep"], "y": ["ydep"]}
+    )
+    create_basic_wheel_for_package(script, "srv", "2.0", depends=["pkg[y]"])
+    create_basic_wheel_for_package(script, "srv", "1.0")
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        *roots,
+    )
+    script.assert_installed(pkg="1.0", srv="1.0", xdep="1.0")
+    script.assert_not_installed("ydep")
+
+
 def test_new_resolver_installed_message(script: PipTestEnvironment) -> None:
     create_basic_wheel_for_package(script, "A", "1.0")
     result = script.pip(
@@ -327,6 +471,32 @@ def test_new_resolver_installs_editable(script: PipTestEnvironment) -> None:
     )
     script.assert_installed(base="0.1.0", dep="0.1.0")
     script.assert_installed_editable("dep")
+
+
+def test_new_resolver_installs_editable_with_extra(
+    script: PipTestEnvironment,
+) -> None:
+    """An editable install requested with an extra stays editable and pulls the
+    extra's dependency; the extras candidate now wraps the editable base."""
+    create_basic_wheel_for_package(script, "dep", "0.1.0")
+    source_dir = create_test_package_with_setup(
+        script,
+        name="pkg",
+        version="0.1.0",
+        extras_require={"dev": ["dep"]},
+    )
+    script.pip(
+        "install",
+        "--no-build-isolation",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "--editable",
+        f"{source_dir}[dev]",
+    )
+    script.assert_installed(pkg="0.1.0", dep="0.1.0")
+    script.assert_installed_editable("pkg")
 
 
 @pytest.mark.parametrize(
@@ -398,9 +568,8 @@ def test_new_resolver_requires_python_error(script: PipTestEnvironment) -> None:
         expect_error=True,
     )
 
-    message = (
-        "Package 'base' requires a different Python: "
-        "{}.{}.{} not in '<2'".format(*sys.version_info[:3])
+    message = "Package 'base' requires a different Python: {}.{}.{} not in '<2'".format(
+        *sys.version_info[:3]
     )
     assert message in result.stderr, str(result)
 
@@ -1159,9 +1328,8 @@ def test_new_resolver_no_deps_checks_requires_python(
         expect_error=True,
     )
 
-    message = (
-        "Package 'base' requires a different Python: "
-        "{}.{}.{} not in '<2'".format(*sys.version_info[:3])
+    message = "Package 'base' requires a different Python: {}.{}.{} not in '<2'".format(
+        *sys.version_info[:3]
     )
     assert message in result.stderr
 
@@ -2405,19 +2573,19 @@ def test_new_resolver_dont_backtrack_on_conflicting_constraints_on_extras(
         *(to_install if not swap_order else reversed(to_install)),
         expect_error=True,
     )
-    assert (
-        "pkg-2.0" not in result.stdout or "pkg-1.0" not in result.stdout
-    ), "Should only try one of 1.0, 2.0 depending on order"
+    assert "pkg-2.0" not in result.stdout or "pkg-1.0" not in result.stdout, (
+        "Should only try one of 1.0, 2.0 depending on order"
+    )
     assert "Reporter.starting()" in result.stdout, (
         "This should never fail unless the debug reporting format has changed,"
         " in which case the other assertions in this test need to be reviewed."
     )
-    assert (
-        "Reporter.rejecting_candidate" not in result.stdout
-    ), "Should be able to conclude conflict before even selecting a candidate"
-    assert (
-        "conflict is caused by" in result.stdout
-    ), "Resolver should be trivially able to find conflict cause"
+    assert "Reporter.rejecting_candidate" not in result.stdout, (
+        "Should be able to conclude conflict before even selecting a candidate"
+    )
+    assert "conflict is caused by" in result.stdout, (
+        "Resolver should be trivially able to find conflict cause"
+    )
 
 
 def test_new_resolver_respect_user_requested_if_extra_is_installed(
@@ -2474,6 +2642,31 @@ def test_new_resolver_constraint_on_link_with_extra(
         "pkg==1",
     )
     script.assert_installed(pkg="1.0")
+
+
+def test_new_resolver_url_constraint_with_extra_request(
+    script: PipTestEnvironment,
+) -> None:
+    """A URL constraint provides the base candidate for a package requested with
+    an extra, so that candidate must be offered carrying the extra."""
+    wheel: pathlib.Path = create_basic_wheel_for_package(
+        script, "pkg", "1.0", extras={"ext": ["ext_dep"]}
+    )
+    create_basic_wheel_for_package(script, "ext_dep", "1.0")
+    constraints = script.scratch_path / "constraints.txt"
+    constraints.write_text(f"pkg @ {wheel.as_uri()}\n")
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "-c",
+        constraints,
+        "pkg[ext]",
+    )
+    script.assert_installed(pkg="1.0", ext_dep="1.0")
 
 
 def test_new_resolver_constraint_on_link_with_extra_indirect(
@@ -2567,4 +2760,29 @@ def test_new_resolver_comes_from_with_extra(
     )
     assert "(from pkg[ext])" in result.stdout
     assert "(from pkg)" not in result.stdout
+    script.assert_installed(pkg="1.0", dep="1.0")
+
+
+def test_new_resolver_comes_from_with_extra_and_version(
+    script: PipTestEnvironment,
+) -> None:
+    """The provenance chain names the extra exactly once, even with a version
+    specifier: it must not duplicate the pkg[ext]==x hop."""
+    create_basic_wheel_for_package(script, "dep", "1.0")
+    create_basic_wheel_for_package(script, "pkg", "1.0", extras={"ext": ["dep"]})
+    req_path = script.scratch_path / "reqs.txt"
+    req_path.write_text("pkg[ext]==1.0")
+
+    result = script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "-r",
+        req_path,
+    )
+
+    assert "(from pkg[ext]==1.0->pkg[ext]==1.0" not in result.stdout, result.stdout
+    assert "(from pkg[ext]==1.0->-r" in result.stdout
     script.assert_installed(pkg="1.0", dep="1.0")


### PR DESCRIPTION
I went down a rabbit hole looking at how extras were implemented in pip from the following issue: https://github.com/pypa/pip/issues/14139

Resolve a project and its extras as one node instead of a separate node per extra. `identify()` returns the bare project name, so `foo` and `foo[extra]` share a node resolved once against the merged set of requested extras. This removes the per-extra nodes and the synthetic base-dependency edges that kept their versions aligned.

In my own [benchmarking suite](https://github.com/notatallshaw/Pip-Resolution-Scenarios-and-Benchmarks) `apache-airflow[all]`, drops from over 11,234 to 2,774 requirements visited, and 740 resolution rounds to 612, and a warm-cache `pip install --dry-run` runs about 8% faster. I found no regressions, although a small number of solutions changes due to the resolver visiting some extras in a different order.

The careful part of this work was that a node stays pinned while any requirement on it holds, so it can keep an extra whose only requester was backtracked away. This requires a pass to rebuild the install set under only the surviving extras and drops that extra's dependencies (the per-extra model got this for free). When nothing is stale it reuses the edges resolvelib already recorded, so performance cost is de minimis.

Finally, this evaluates marker evaluation on the requirement node and causes a dependency with  `; extra != "x"`  to no longer be pulled in when `x` is requested, this does not help solve this problem for transitive resolutions though, see the discussion in https://discuss.python.org/t/ban-negative-extras-for-extras-marker/108022