### PR TITLE
Respect --uploaded-prior-to in pip list

### DIFF
--- a/news/14189.bugfix.rst
+++ b/news/14189.bugfix.rst
@@ -1,0 +1,2 @@
+Respect ``--uploaded-prior-to`` in ``pip list --outdated`` and
+``pip list --uptodate`` when determining the latest available version.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -510,7 +510,7 @@ def uploaded_prior_to() -> Option:
             "Accepts an ISO 8601 datetime (e.g., '2023-01-01T00:00:00Z', "
             "uses local timezone if none specified) or a duration in days "
             "(e.g., 'P3D' for packages uploaded at least 3 days ago). "
-            "Only effective when installing from indexes that provide "
+            "Only effective when using indexes that provide "
             "upload-time metadata."
         ),
     )

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -165,6 +165,7 @@ class ListCommand(IndexGroupCommand):
         return PackageFinder.create(
             link_collector=link_collector,
             selection_prefs=selection_prefs,
+            uploaded_prior_to=options.uploaded_prior_to,
         )
 
     def run(self, options: Values, args: list[str]) -> int:

--- a/tests/functional/test_uploaded_prior_to.py
+++ b/tests/functional/test_uploaded_prior_to.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import json
+from typing import TYPE_CHECKING
+
 import pytest
 
 from tests.lib import PipTestEnvironment, TestData
 from tests.lib.server import (
     file_response,
+    json_index_page,
     make_mock_server,
     package_page,
     server_running,
 )
+
+if TYPE_CHECKING:
+    from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
 
 
 class TestUploadedPriorTo:
@@ -132,3 +139,100 @@ class TestUploadedPriorTo:
             "--uploaded-prior-to=2000-01-01T00:00:00", "simple==1.0"
         )
         assert "Successfully installed simple-1.0" in result.stdout
+
+    def test_uploaded_prior_to_list_outdated(self, script: PipTestEnvironment) -> None:
+        """Test that list --outdated applies upload-time filtering to Latest."""
+        script.pip_install_local("simple==1.0")
+
+        files = [
+            {
+                "url": "simple-1.0.tar.gz",
+                "hashes": {},
+                "upload-time": "2020-01-01T00:00:00Z",
+            },
+            {
+                "url": "simple-2.0.tar.gz",
+                "hashes": {},
+                "upload-time": "2020-06-01T00:00:00Z",
+            },
+            {
+                "url": "simple-3.0.tar.gz",
+                "hashes": {},
+                "upload-time": "2021-01-01T00:00:00Z",
+            },
+        ]
+
+        def index_router(
+            environ: WSGIEnvironment, start_response: StartResponse
+        ) -> WSGIApplication:
+            name = environ["PATH_INFO"].strip("/")
+            return json_index_page(name, files if name == "simple" else [])
+
+        server = make_mock_server()
+        server.mock.side_effect = index_router
+
+        with server_running(server):
+            args = [
+                "list",
+                "--index-url",
+                f"http://{server.host}:{server.port}",
+                "--format=json",
+            ]
+
+            result = script.pip(*args, "--outdated")
+            assert {
+                "name": "simple",
+                "version": "1.0",
+                "latest_version": "3.0",
+                "latest_filetype": "sdist",
+            } in json.loads(result.stdout)
+
+            result = script.pip(
+                *args, "--outdated", "--uploaded-prior-to=2020-12-31T00:00:00Z"
+            )
+            assert {
+                "name": "simple",
+                "version": "1.0",
+                "latest_version": "2.0",
+                "latest_filetype": "sdist",
+            } in json.loads(result.stdout)
+
+            result = script.pip(
+                *args, "--outdated", "--uploaded-prior-to=2020-03-01T00:00:00Z"
+            )
+            assert "simple" not in {p["name"] for p in json.loads(result.stdout)}
+
+            # The same cutoff must leave 1.0 as the best candidate, making the
+            # package up-to-date rather than filtered out entirely.
+            result = script.pip(
+                *args, "--uptodate", "--uploaded-prior-to=2020-03-01T00:00:00Z"
+            )
+            assert {"name": "simple", "version": "1.0"} in json.loads(result.stdout)
+
+    def test_uploaded_prior_to_list_outdated_no_upload_time(
+        self, script: PipTestEnvironment
+    ) -> None:
+        """Test that list --outdated errors if the index lacks upload-time."""
+        script.pip_install_local("simple==1.0")
+
+        def index_router(
+            environ: WSGIEnvironment, start_response: StartResponse
+        ) -> WSGIApplication:
+            if environ["PATH_INFO"] == "/simple/":
+                return package_page({"simple-2.0.tar.gz": "/files/simple-2.0.tar.gz"})
+            return package_page({})
+
+        server = make_mock_server()
+        server.mock.side_effect = index_router
+
+        with server_running(server):
+            result = script.pip(
+                "list",
+                "--index-url",
+                f"http://{server.host}:{server.port}",
+                "--outdated",
+                "--uploaded-prior-to=2100-01-01T00:00:00",
+                expect_error=True,
+            )
+
+        assert "does not provide upload-time metadata" in result.stderr

--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 import ssl
 import threading
@@ -165,6 +166,25 @@ def package_page(spec: dict[str, str]) -> "WSGIApplication":
 
     links = "".join(link(*kv) for kv in spec.items())
     return text_html_response(html5_page(links))
+
+
+def json_index_page(name: str, files: Iterable[dict[str, Any]]) -> "WSGIApplication":
+    page = {
+        "meta": {"api-version": "1.0"},
+        "name": name,
+        "files": list(files),
+    }
+
+    def responder(environ: "WSGIEnvironment", start_response: "StartResponse") -> Body:
+        start_response(
+            "200 OK",
+            [
+                ("Content-Type", "application/vnd.pypi.simple.v1+json"),
+            ],
+        )
+        return [json.dumps(page).encode("utf-8")]
+
+    return responder
 
 
 def file_response(path: pathlib.Path) -> "WSGIApplication":


### PR DESCRIPTION
`pip list --outdated`/`--uptodate` accepted `--uploaded-prior-to` but ignored it when resolving the latest version. Pass it to the package finder like install and download already do.